### PR TITLE
Fix x-ms-version header mismatch

### DIFF
--- a/Common/Helpers/HttpClientHelper.cs
+++ b/Common/Helpers/HttpClientHelper.cs
@@ -328,7 +328,6 @@ namespace RecurringIntegrationsScheduler.Common.Helpers
         {
             _httpClient.DefaultRequestHeaders.Clear();
             _httpClient.DefaultRequestHeaders.Add("x-ms-date", DateTime.UtcNow.ToString("R", System.Globalization.CultureInfo.InvariantCulture));
-            _httpClient.DefaultRequestHeaders.Add("x-ms-version", "2015-02-21");
             _httpClient.DefaultRequestHeaders.Add("x-ms-blob-type", "BlockBlob");
             _httpClient.DefaultRequestHeaders.Add("Overwrite", "T");
             return await _retryPolicy.ExecuteAsync(() => _httpClient.PutAsync(blobUrl.AbsoluteUri, new StreamContent(stream)));


### PR DESCRIPTION
We do not need to send the `x-ms-version` header, as the SAS token
already contains the necessary version information for the Blob storage
endpoint. This fix will make DevBoxes work with Azure Storage Emulator.

Fixes #19.