### PR TITLE
Initialize default Odata actions path when there is no Context to use

### DIFF
--- a/Common/JobSettings/Settings.cs
+++ b/Common/JobSettings/Settings.cs
@@ -154,6 +154,57 @@ namespace RecurringIntegrationsScheduler.Common.JobSettings
             }
         }
 
+        /// <summary>
+        /// This method can be used to initialize default Odata action path values when there is no context to use.
+        /// </summary>
+        public void InitializeDefaultOdataActionPath()
+        {
+            if (string.IsNullOrEmpty(ImportFromPackageActionPath))
+            {
+                ImportFromPackageActionPath = OdataActionsConstants.ImportFromPackageActionPath;
+            }
+
+            if (string.IsNullOrEmpty(GetAzureWriteUrlActionPath))
+            {
+                GetAzureWriteUrlActionPath = OdataActionsConstants.GetAzureWriteUrlActionPath;
+            }
+
+            if (string.IsNullOrEmpty(GetExecutionSummaryStatusActionPath))
+            {
+                GetExecutionSummaryStatusActionPath = OdataActionsConstants.GetExecutionSummaryStatusActionPath;
+            }
+
+            if (string.IsNullOrEmpty(GetExportedPackageUrlActionPath))
+            {
+                GetExportedPackageUrlActionPath = OdataActionsConstants.GetExportedPackageUrlActionPath;
+            }
+
+            if (string.IsNullOrEmpty(GetExecutionSummaryPageUrlActionPath))
+            {
+                GetExecutionSummaryPageUrlActionPath = OdataActionsConstants.GetExecutionSummaryPageUrlActionPath;
+            }
+
+            if (string.IsNullOrEmpty(DeleteExecutionHistoryJobActionPath))
+            {
+                DeleteExecutionHistoryJobActionPath = OdataActionsConstants.DeleteExecutionHistoryJobActionPath;
+            }
+
+            if (string.IsNullOrEmpty(ExportToPackageActionPath))
+            {
+                ExportToPackageActionPath = OdataActionsConstants.ExportToPackageActionPath;
+            }
+
+            if (string.IsNullOrEmpty(ExportFromPackageActionPath))
+            {
+                ExportFromPackageActionPath = OdataActionsConstants.ExportFromPackageActionPath;
+            }
+
+            if (string.IsNullOrEmpty(GetMessageStatusActionPath))
+            {
+                GetMessageStatusActionPath = OdataActionsConstants.GetMessageStatusActionPath;
+            }
+        }
+
         #region Members
 
         /// <summary>

--- a/Scheduler/Forms/ValidateConnection.cs
+++ b/Scheduler/Forms/ValidateConnection.cs
@@ -68,6 +68,9 @@ namespace RecurringIntegrationsScheduler.Forms
 
             var settings = new Common.JobSettings.DownloadJobSettings();
 
+            // Initialize default Odata action path as we do not have any context to use
+            settings.InitializeDefaultOdataActionPath();
+
             Guid.TryParse(application.ClientId, out Guid aadClientGuid);
             settings.AadClientId = aadClientGuid;
             settings.AadClientSecret = EncryptDecrypt.Decrypt(application.Secret);


### PR DESCRIPTION
In scenarios where there is not context to retrieve Odata actions relative path from, It is required to have a way to fallback to the default actions. Therefor this changeset will provide a method to be able to call to initialize the default values. This extra method is now i.e. used on the "ValidateConnection.cs" where the initial connection between the RIS and the Backend services is getting verified.