### PR TITLE
Log exception even if exception message is empty

### DIFF
--- a/Job.Download/Download.cs
+++ b/Job.Download/Download.cs
@@ -129,7 +129,13 @@ namespace RecurringIntegrationsScheduler.Job
                 if (Log.IsDebugEnabled)
                 {
                     if (!string.IsNullOrEmpty(ex.Message))
+                    {
                         Log.Error(ex.Message, ex);
+                    }
+                    else
+                    {
+                        Log.Error("Uknown exception", ex);
+                    }
 
                     while (ex.InnerException != null)
                     {

--- a/Job.ExecutionMonitor/ExecutionMonitor.cs
+++ b/Job.ExecutionMonitor/ExecutionMonitor.cs
@@ -119,7 +119,13 @@ namespace RecurringIntegrationsScheduler.Job
                 if (Log.IsDebugEnabled)
                 {
                     if (!string.IsNullOrEmpty(ex.Message))
+                    {
                         Log.Error(ex.Message, ex);
+                    }
+                    else
+                    {
+                        Log.Error("Uknown exception", ex);
+                    }
 
                     while (ex.InnerException != null)
                     {

--- a/Job.Export/Export.cs
+++ b/Job.Export/Export.cs
@@ -109,7 +109,13 @@ namespace RecurringIntegrationsScheduler.Job
                 if (Log.IsDebugEnabled)
                 {
                     if (!string.IsNullOrEmpty(ex.Message))
+                    {
                         Log.Error(ex.Message, ex);
+                    }
+                    else
+                    {
+                        Log.Error("Uknown exception", ex);
+                    }
 
                     while (ex.InnerException != null)
                     {

--- a/Job.Import/Import.cs
+++ b/Job.Import/Import.cs
@@ -122,7 +122,13 @@ namespace RecurringIntegrationsScheduler.Job
                 if (Log.IsDebugEnabled)
                 {
                     if (!string.IsNullOrEmpty(ex.Message))
+                    {
                         Log.Error(ex.Message, ex);
+                    }
+                    else
+                    {
+                        Log.Error("Uknown exception", ex);
+                    }
 
                     while (ex.InnerException != null)
                     {

--- a/Job.ProcessingMonitor/ProcessingMonitor.cs
+++ b/Job.ProcessingMonitor/ProcessingMonitor.cs
@@ -120,7 +120,13 @@ namespace RecurringIntegrationsScheduler.Job
                 if (Log.IsDebugEnabled)
                 {
                     if (!string.IsNullOrEmpty(ex.Message))
+                    {
                         Log.Error(ex.Message, ex);
+                    }
+                    else
+                    {
+                        Log.Error("Uknown exception", ex);
+                    }
 
                     while (ex.InnerException != null)
                     {

--- a/Job.Upload/Upload.cs
+++ b/Job.Upload/Upload.cs
@@ -118,7 +118,13 @@ namespace RecurringIntegrationsScheduler.Job
                 if (Log.IsDebugEnabled)
                 {
                     if (!string.IsNullOrEmpty(ex.Message))
+                    {
                         Log.Error(ex.Message, ex);
+                    }
+                    else
+                    {
+                        Log.Error("Uknown exception", ex);
+                    }
 
                     while (ex.InnerException != null)
                     {


### PR DESCRIPTION
In some scenarios it happens that the Exceptions are not logged because of the fact that the Exception message is empty.
This changeset will enable exception logging for the import jobs even when the exception message is null or empty string.