### PR TITLE
Pause Jobs Indefinitely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,4 @@ __pycache__/
 /Setup/Quartz.Serialization.Json.dll
 /Setup/Quartz.Plugins.dll
 /Setup/Quartz.Jobs.dll
+/Setup/Quartz.dll

--- a/Common/Contracts/SettingsConstants.cs
+++ b/Common/Contracts/SettingsConstants.cs
@@ -75,6 +75,11 @@ namespace RecurringIntegrationsScheduler.Common.Contracts
         public const string PauseJobOnException = "PauseJobOnException";
 
         /// <summary>
+        /// Pause job indefinitely
+        /// </summary>
+        public const string IndefinitePause = "IndefinitePause";
+
+        /// <summary>
         /// The relative path to the ImportFromPackage Odata action
         /// </summary>
         public const string ImportFromPackageActionPath = "ImportFromPackageActionPath";

--- a/Common/JobSettings/Settings.cs
+++ b/Common/JobSettings/Settings.cs
@@ -99,6 +99,8 @@ namespace RecurringIntegrationsScheduler.Common.JobSettings
 
             PauseJobOnException = Convert.ToBoolean(dataMap.GetString(SettingsConstants.PauseJobOnException));
 
+            IndefinitePause = Convert.ToBoolean(dataMap.GetString(SettingsConstants.IndefinitePause));
+
             ImportFromPackageActionPath = dataMap.GetString(SettingsConstants.ImportFromPackageActionPath);
             if (string.IsNullOrEmpty(ImportFromPackageActionPath))
             {
@@ -251,6 +253,14 @@ namespace RecurringIntegrationsScheduler.Common.JobSettings
         /// <c>true</c> if [pause job when exception occurs]; otherwise, <c>false</c>.
         /// </value>
         public bool PauseJobOnException { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the job is paused indefinitely or not.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [pause job indefinitely]; otherwise, <c>false</c>.
+        /// </value>
+        public bool IndefinitePause { get; set; }
 
         /// <summary>
         /// Get the ImportFromPackage Odata action relative path

--- a/Common/packages.config
+++ b/Common/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
   <package id="System.Linq.Dynamic" version="1.0.7" targetFramework="net45" />
 </packages>

--- a/Job.Download/Download.cs
+++ b/Job.Download/Download.cs
@@ -95,6 +95,14 @@ namespace RecurringIntegrationsScheduler.Job
                 _context = context;
                 _settings.Initialize(context);
 
+                if (_settings.IndefinitePause)
+                {
+                    await context.Scheduler.PauseJob(context.JobDetail.Key);
+                    Log.InfoFormat(CultureInfo.InvariantCulture,
+                        string.Format(Resources.Job_0_was_paused_indefinitely, _context.JobDetail.Key));
+                    return;
+                }
+
                 _retryPolicyForIo = Policy.Handle<IOException>().WaitAndRetry(
                     retryCount: _settings.RetryCount, 
                     sleepDurationProvider: attempt => TimeSpan.FromSeconds(_settings.RetryDelay),

--- a/Job.Download/Properties/Resources.Designer.cs
+++ b/Job.Download/Properties/Resources.Designer.cs
@@ -221,5 +221,14 @@ namespace RecurringIntegrationsScheduler.Job.Properties {
                 return ResourceManager.GetString("Job_0_was_paused_because_of_error", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Job: {0} was paused indefinitely..
+        /// </summary>
+        internal static string Job_0_was_paused_indefinitely {
+            get {
+                return ResourceManager.GetString("Job_0_was_paused_indefinitely", resourceCulture);
+            }
+        }
     }
 }

--- a/Job.Download/Properties/Resources.resx
+++ b/Job.Download/Properties/Resources.resx
@@ -171,4 +171,7 @@
   <data name="Job_0_thrown_an_error_1" xml:space="preserve">
     <value>Job: {0} thrown an error. Exception : {1}</value>
   </data>
+  <data name="Job_0_was_paused_indefinitely" xml:space="preserve">
+    <value>Job: {0} was paused indefinitely.</value>
+  </data>
 </root>

--- a/Job.Download/packages.config
+++ b/Job.Download/packages.config
@@ -3,5 +3,5 @@
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
 </packages>

--- a/Job.ExecutionMonitor/ExecutionMonitor.cs
+++ b/Job.ExecutionMonitor/ExecutionMonitor.cs
@@ -86,6 +86,14 @@ namespace RecurringIntegrationsScheduler.Job
                 _context = context;
                 _settings.Initialize(context);
 
+                if (_settings.IndefinitePause)
+                {
+                    await context.Scheduler.PauseJob(context.JobDetail.Key);
+                    Log.InfoFormat(CultureInfo.InvariantCulture,
+                        string.Format(Resources.Job_0_was_paused_indefinitely, _context.JobDetail.Key));
+                    return;
+                }
+
                 _retryPolicyForIo = Policy.Handle<IOException>().WaitAndRetry(
                     retryCount: _settings.RetryCount, 
                     sleepDurationProvider: attempt => TimeSpan.FromSeconds(_settings.RetryDelay),

--- a/Job.ExecutionMonitor/Properties/Resources.Designer.cs
+++ b/Job.ExecutionMonitor/Properties/Resources.Designer.cs
@@ -185,5 +185,14 @@ namespace RecurringIntegrationsScheduler.Job.Properties {
                 return ResourceManager.GetString("Job_0_was_paused_because_of_error", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Job: {0} was paused indefinitely..
+        /// </summary>
+        internal static string Job_0_was_paused_indefinitely {
+            get {
+                return ResourceManager.GetString("Job_0_was_paused_indefinitely", resourceCulture);
+            }
+        }
     }
 }

--- a/Job.ExecutionMonitor/Properties/Resources.resx
+++ b/Job.ExecutionMonitor/Properties/Resources.resx
@@ -159,4 +159,7 @@
   <data name="Job_0_thrown_an_error_1" xml:space="preserve">
     <value>Job: {0} thrown an error. Exception : {1}</value>
   </data>
+  <data name="Job_0_was_paused_indefinitely" xml:space="preserve">
+    <value>Job: {0} was paused indefinitely.</value>
+  </data>
 </root>

--- a/Job.ExecutionMonitor/packages.config
+++ b/Job.ExecutionMonitor/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
 </packages>

--- a/Job.Export/Export.cs
+++ b/Job.Export/Export.cs
@@ -75,6 +75,14 @@ namespace RecurringIntegrationsScheduler.Job
                 _context = context;
                 _settings.Initialize(context);
 
+                if (_settings.IndefinitePause)
+                {
+                    await context.Scheduler.PauseJob(context.JobDetail.Key);
+                    Log.InfoFormat(CultureInfo.InvariantCulture,
+                        string.Format(Resources.Job_0_was_paused_indefinitely, _context.JobDetail.Key));
+                    return;
+                }
+
                 _retryPolicyForIo = Policy.Handle<IOException>().WaitAndRetry(
                     retryCount: _settings.RetryCount, 
                     sleepDurationProvider: attempt => TimeSpan.FromSeconds(_settings.RetryDelay),

--- a/Job.Export/Properties/Resources.Designer.cs
+++ b/Job.Export/Properties/Resources.Designer.cs
@@ -257,5 +257,14 @@ namespace RecurringIntegrationsScheduler.Job.Properties {
                 return ResourceManager.GetString("Job_0_was_paused_because_of_error", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Job: {0} was paused indefinitely..
+        /// </summary>
+        internal static string Job_0_was_paused_indefinitely {
+            get {
+                return ResourceManager.GetString("Job_0_was_paused_indefinitely", resourceCulture);
+            }
+        }
     }
 }

--- a/Job.Export/Properties/Resources.resx
+++ b/Job.Export/Properties/Resources.resx
@@ -183,4 +183,7 @@
   <data name="Job_0_Trying_to_get_exported_package_URL_Try_1" xml:space="preserve">
     <value>Job: {0} Trying to get exported package URL. Try: {1}</value>
   </data>
+  <data name="Job_0_was_paused_indefinitely" xml:space="preserve">
+    <value>Job: {0} was paused indefinitely.</value>
+  </data>
 </root>

--- a/Job.Export/packages.config
+++ b/Job.Export/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
 </packages>

--- a/Job.Import/Import.cs
+++ b/Job.Import/Import.cs
@@ -88,6 +88,14 @@ namespace RecurringIntegrationsScheduler.Job
                 _context = context;
                 _settings.Initialize(context);
 
+                if (_settings.IndefinitePause)
+                {
+                    await context.Scheduler.PauseJob(context.JobDetail.Key);
+                    Log.InfoFormat(CultureInfo.InvariantCulture,
+                        string.Format(Resources.Job_0_was_paused_indefinitely, _context.JobDetail.Key));
+                    return;
+                }
+
                 _retryPolicyForIo = Policy.Handle<IOException>().WaitAndRetry(
                     retryCount: _settings.RetryCount, 
                     sleepDurationProvider: attempt => TimeSpan.FromSeconds(_settings.RetryDelay),

--- a/Job.Import/Properties/Resources.Designer.cs
+++ b/Job.Import/Properties/Resources.Designer.cs
@@ -214,6 +214,15 @@ namespace RecurringIntegrationsScheduler.Job.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Job: {0} was paused indefinitely..
+        /// </summary>
+        internal static string Job_0_was_paused_indefinitely {
+            get {
+                return ResourceManager.GetString("Job_0_was_paused_indefinitely", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package template contains input file: {0}. Please remove it from the template..
         /// </summary>
         internal static string Package_template_contains_input_file_0_Please_remove_it_from_the_template {

--- a/Job.Import/Properties/Resources.resx
+++ b/Job.Import/Properties/Resources.resx
@@ -171,4 +171,7 @@
   <data name="Job_0_thrown_an_error_1" xml:space="preserve">
     <value>Job: {0} thrown an error. Exception : {1}</value>
   </data>
+  <data name="Job_0_was_paused_indefinitely" xml:space="preserve">
+    <value>Job: {0} was paused indefinitely.</value>
+  </data>
 </root>

--- a/Job.Import/packages.config
+++ b/Job.Import/packages.config
@@ -3,5 +3,5 @@
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
 </packages>

--- a/Job.ProcessingMonitor/ProcessingMonitor.cs
+++ b/Job.ProcessingMonitor/ProcessingMonitor.cs
@@ -86,6 +86,14 @@ namespace RecurringIntegrationsScheduler.Job
                 _context = context;
                 _settings.Initialize(context);
 
+                if (_settings.IndefinitePause)
+                {
+                    await context.Scheduler.PauseJob(context.JobDetail.Key);
+                    Log.InfoFormat(CultureInfo.InvariantCulture,
+                        string.Format(Resources.Job_0_was_paused_indefinitely, _context.JobDetail.Key));
+                    return;
+                }
+
                 _retryPolicyForIo = Policy.Handle<IOException>().WaitAndRetry(
                     retryCount: _settings.RetryCount, 
                     sleepDurationProvider: attempt => TimeSpan.FromSeconds(_settings.RetryDelay),

--- a/Job.ProcessingMonitor/Properties/Resources.Designer.cs
+++ b/Job.ProcessingMonitor/Properties/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace RecurringIntegrationsScheduler.Job.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Job: {0} was paused indefinitely..
+        /// </summary>
+        internal static string Job_0_was_paused_indefinitely {
+            get {
+                return ResourceManager.GetString("Job_0_was_paused_indefinitely", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Processing monitor job: {0} failed.
         /// </summary>
         internal static string Processing_monitor_job_0_failed {

--- a/Job.ProcessingMonitor/Properties/Resources.resx
+++ b/Job.ProcessingMonitor/Properties/Resources.resx
@@ -159,4 +159,7 @@
   <data name="Job_0_thrown_an_error_1" xml:space="preserve">
     <value>Job: {0} thrown an error. Exception : {1}</value>
   </data>
+  <data name="Job_0_was_paused_indefinitely" xml:space="preserve">
+    <value>Job: {0} was paused indefinitely.</value>
+  </data>
 </root>

--- a/Job.ProcessingMonitor/packages.config
+++ b/Job.ProcessingMonitor/packages.config
@@ -3,5 +3,5 @@
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
 </packages>

--- a/Job.Upload/Properties/Resources.Designer.cs
+++ b/Job.Upload/Properties/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace RecurringIntegrationsScheduler.Job.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Job: {0} was paused indefinitely..
+        /// </summary>
+        internal static string Job_0_was_paused_indefinitely {
+            get {
+                return ResourceManager.GetString("Job_0_was_paused_indefinitely", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Upload job: {0} failed.
         /// </summary>
         internal static string Upload_job_0_failed {

--- a/Job.Upload/Properties/Resources.resx
+++ b/Job.Upload/Properties/Resources.resx
@@ -168,4 +168,7 @@
   <data name="Job_0_thrown_an_error_1" xml:space="preserve">
     <value>Job: {0} thrown an error. Exception : {1}</value>
   </data>
+  <data name="Job_0_was_paused_indefinitely" xml:space="preserve">
+    <value>Job: {0} was paused indefinitely.</value>
+  </data>
 </root>

--- a/Job.Upload/Upload.cs
+++ b/Job.Upload/Upload.cs
@@ -84,6 +84,14 @@ namespace RecurringIntegrationsScheduler.Job
                 _context = context;
                 _settings.Initialize(context);
 
+                if (_settings.IndefinitePause)
+                {
+                    await context.Scheduler.PauseJob(context.JobDetail.Key);
+                    Log.InfoFormat(CultureInfo.InvariantCulture,
+                        string.Format(Resources.Job_0_was_paused_indefinitely, _context.JobDetail.Key));
+                    return;
+                }
+
                 _retryPolicyForIo = Policy.Handle<IOException>().WaitAndRetry(
                     retryCount: _settings.RetryCount, 
                     sleepDurationProvider: attempt => TimeSpan.FromSeconds(_settings.RetryDelay),

--- a/Job.Upload/packages.config
+++ b/Job.Upload/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
 </packages>

--- a/Scheduler/Forms/DownloadJob.Designer.cs
+++ b/Scheduler/Forms/DownloadJob.Designer.cs
@@ -62,6 +62,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.instanceLabel = new System.Windows.Forms.Label();
             this.instanceComboBox = new System.Windows.Forms.ComboBox();
             this.recurrenceGroupBox = new System.Windows.Forms.GroupBox();
+            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
             this.moreExamplesButton = new System.Windows.Forms.Button();
             this.calculatedRunsTextBox = new System.Windows.Forms.TextBox();
             this.calculateNextRunsButton = new System.Windows.Forms.Button();
@@ -120,11 +121,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
-            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(345, 463);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(230, 301);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -133,9 +132,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.deletePackageCheckBox.AutoSize = true;
             this.deletePackageCheckBox.Enabled = false;
-            this.deletePackageCheckBox.Location = new System.Drawing.Point(18, 425);
+            this.deletePackageCheckBox.Location = new System.Drawing.Point(12, 276);
+            this.deletePackageCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.deletePackageCheckBox.Name = "deletePackageCheckBox";
-            this.deletePackageCheckBox.Size = new System.Drawing.Size(171, 24);
+            this.deletePackageCheckBox.Size = new System.Drawing.Size(118, 17);
             this.deletePackageCheckBox.TabIndex = 14;
             this.deletePackageCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Delete_package_file;
             this.deletePackageCheckBox.UseVisualStyleBackColor = true;
@@ -144,9 +144,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.addTimestampCheckBox.AutoSize = true;
             this.addTimestampCheckBox.Enabled = false;
-            this.addTimestampCheckBox.Location = new System.Drawing.Point(18, 394);
+            this.addTimestampCheckBox.Location = new System.Drawing.Point(12, 256);
+            this.addTimestampCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.addTimestampCheckBox.Name = "addTimestampCheckBox";
-            this.addTimestampCheckBox.Size = new System.Drawing.Size(260, 24);
+            this.addTimestampCheckBox.Size = new System.Drawing.Size(177, 17);
             this.addTimestampCheckBox.TabIndex = 13;
             this.addTimestampCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Make_exported_file_name_unique;
             this.addTimestampCheckBox.UseVisualStyleBackColor = true;
@@ -154,9 +155,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // unzipCheckBox
             // 
             this.unzipCheckBox.AutoSize = true;
-            this.unzipCheckBox.Location = new System.Drawing.Point(18, 363);
+            this.unzipCheckBox.Location = new System.Drawing.Point(12, 236);
+            this.unzipCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.unzipCheckBox.Name = "unzipCheckBox";
-            this.unzipCheckBox.Size = new System.Drawing.Size(165, 24);
+            this.unzipCheckBox.Size = new System.Drawing.Size(114, 17);
             this.unzipCheckBox.TabIndex = 12;
             this.unzipCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Unzip_package_file;
             this.unzipCheckBox.UseVisualStyleBackColor = true;
@@ -167,10 +169,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(18, 265);
-            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(12, 172);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(213, 24);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(143, 17);
             this.useStandardSubfolder.TabIndex = 8;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_folder_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -181,10 +182,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.errorsFolderBrowserButton.Enabled = false;
             this.errorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.errorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(303, 317);
+            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(202, 206);
             this.errorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.errorsFolderBrowserButton.Name = "errorsFolderBrowserButton";
-            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.errorsFolderBrowserButton.TabIndex = 7;
             this.errorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.errorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -193,19 +194,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // errorsFolder
             // 
             this.errorsFolder.Enabled = false;
-            this.errorsFolder.Location = new System.Drawing.Point(18, 323);
-            this.errorsFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.errorsFolder.Location = new System.Drawing.Point(12, 210);
             this.errorsFolder.Name = "errorsFolder";
-            this.errorsFolder.Size = new System.Drawing.Size(278, 26);
+            this.errorsFolder.Size = new System.Drawing.Size(187, 20);
             this.errorsFolder.TabIndex = 6;
             // 
             // errorsFolderLabel
             // 
             this.errorsFolderLabel.AutoSize = true;
-            this.errorsFolderLabel.Location = new System.Drawing.Point(14, 297);
-            this.errorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.errorsFolderLabel.Location = new System.Drawing.Point(9, 193);
             this.errorsFolderLabel.Name = "errorsFolderLabel";
-            this.errorsFolderLabel.Size = new System.Drawing.Size(96, 20);
+            this.errorsFolderLabel.Size = new System.Drawing.Size(63, 13);
             this.errorsFolderLabel.TabIndex = 11;
             this.errorsFolderLabel.Text = "Errors folder";
             // 
@@ -213,10 +212,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.downloadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.downloadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(303, 222);
+            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(202, 144);
             this.downloadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.downloadFolderBrowserButton.Name = "downloadFolderBrowserButton";
-            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.downloadFolderBrowserButton.TabIndex = 5;
             this.downloadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.downloadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -224,39 +223,35 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // downloadFolder
             // 
-            this.downloadFolder.Location = new System.Drawing.Point(20, 226);
-            this.downloadFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.downloadFolder.Location = new System.Drawing.Point(13, 147);
             this.downloadFolder.Name = "downloadFolder";
-            this.downloadFolder.Size = new System.Drawing.Size(278, 26);
+            this.downloadFolder.Size = new System.Drawing.Size(187, 20);
             this.downloadFolder.TabIndex = 4;
             this.downloadFolder.TextChanged += new System.EventHandler(this.DownloadFolder_TextChanged);
             // 
             // downloadFolderLabel
             // 
             this.downloadFolderLabel.AutoSize = true;
-            this.downloadFolderLabel.Location = new System.Drawing.Point(15, 200);
-            this.downloadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.downloadFolderLabel.Location = new System.Drawing.Point(10, 130);
             this.downloadFolderLabel.Name = "downloadFolderLabel";
-            this.downloadFolderLabel.Size = new System.Drawing.Size(124, 20);
+            this.downloadFolderLabel.Size = new System.Drawing.Size(84, 13);
             this.downloadFolderLabel.TabIndex = 8;
             this.downloadFolderLabel.Text = "Download folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(16, 140);
-            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDescription.Location = new System.Drawing.Point(11, 91);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(314, 52);
+            this.jobDescription.Size = new System.Drawing.Size(211, 35);
             this.jobDescription.TabIndex = 3;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(14, 114);
-            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(9, 74);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
             this.jobDescriptionLabel.TabIndex = 4;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -264,38 +259,34 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
-            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 2;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(14, 80);
-            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobGroupLabel.Location = new System.Drawing.Point(9, 52);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
+            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
             this.jobGroupLabel.TabIndex = 2;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(75, 26);
-            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobName.Location = new System.Drawing.Point(50, 17);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(258, 26);
+            this.jobName.Size = new System.Drawing.Size(173, 20);
             this.jobName.TabIndex = 1;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(14, 31);
-            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobNameLabel.Location = new System.Drawing.Point(9, 20);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
+            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -310,11 +301,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(20, 492);
-            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(13, 320);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 237);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 154);
             this.axDetailsGroupBox.TabIndex = 1;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -322,10 +311,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(14, 158);
-            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(9, 103);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
             this.aadApplicationLabel.TabIndex = 34;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -333,29 +321,26 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(159, 155);
-            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(106, 101);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(174, 28);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(117, 21);
             this.aadApplicationComboBox.TabIndex = 33;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(12, 106);
-            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.authMethodPanel.Location = new System.Drawing.Point(8, 69);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(321, 38);
+            this.authMethodPanel.Size = new System.Drawing.Size(214, 25);
             this.authMethodPanel.TabIndex = 31;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
-            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
             this.serviceAuthRadioButton.TabIndex = 16;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -365,10 +350,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
             this.userAuthRadioButton.TabIndex = 15;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -377,10 +361,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // dataJobLabel
             // 
             this.dataJobLabel.AutoSize = true;
-            this.dataJobLabel.Location = new System.Drawing.Point(30, 71);
-            this.dataJobLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.dataJobLabel.Location = new System.Drawing.Point(20, 46);
             this.dataJobLabel.Name = "dataJobLabel";
-            this.dataJobLabel.Size = new System.Drawing.Size(69, 20);
+            this.dataJobLabel.Size = new System.Drawing.Size(47, 13);
             this.dataJobLabel.TabIndex = 22;
             this.dataJobLabel.Text = "Data job";
             // 
@@ -388,19 +371,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.dataJobComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.dataJobComboBox.FormattingEnabled = true;
-            this.dataJobComboBox.Location = new System.Drawing.Point(114, 66);
-            this.dataJobComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.dataJobComboBox.Location = new System.Drawing.Point(76, 43);
             this.dataJobComboBox.Name = "dataJobComboBox";
-            this.dataJobComboBox.Size = new System.Drawing.Size(218, 28);
+            this.dataJobComboBox.Size = new System.Drawing.Size(147, 21);
             this.dataJobComboBox.TabIndex = 11;
             // 
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(98, 198);
-            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.userLabel.Location = new System.Drawing.Point(65, 129);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(43, 20);
+            this.userLabel.Size = new System.Drawing.Size(29, 13);
             this.userLabel.TabIndex = 19;
             this.userLabel.Text = "User";
             // 
@@ -408,19 +389,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(159, 195);
-            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userComboBox.Location = new System.Drawing.Point(106, 127);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(174, 28);
+            this.userComboBox.Size = new System.Drawing.Size(117, 21);
             this.userComboBox.TabIndex = 10;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(30, 31);
-            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.instanceLabel.Location = new System.Drawing.Point(20, 20);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
+            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
             this.instanceLabel.TabIndex = 16;
             this.instanceLabel.Text = "Instance";
             // 
@@ -428,14 +407,14 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(114, 26);
-            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.instanceComboBox.Location = new System.Drawing.Point(76, 17);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
+            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
             this.instanceComboBox.TabIndex = 9;
             // 
             // recurrenceGroupBox
             // 
+            this.recurrenceGroupBox.Controls.Add(this.pauseIndefinitelyCheckBox);
             this.recurrenceGroupBox.Controls.Add(this.moreExamplesButton);
             this.recurrenceGroupBox.Controls.Add(this.calculatedRunsTextBox);
             this.recurrenceGroupBox.Controls.Add(this.calculateNextRunsButton);
@@ -452,21 +431,29 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.startAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.minutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.hoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(372, 20);
-            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(248, 13);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 668);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 455);
             this.recurrenceGroupBox.TabIndex = 2;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
             // 
+            // pauseIndefinitelyCheckBox
+            // 
+            this.pauseIndefinitelyCheckBox.AutoSize = true;
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(9, 20);
+            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
+            this.pauseIndefinitelyCheckBox.TabIndex = 0;
+            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
+            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(237, 534);
-            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.moreExamplesButton.Location = new System.Drawing.Point(158, 370);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(99, 102);
+            this.moreExamplesButton.Size = new System.Drawing.Size(66, 66);
             this.moreExamplesButton.TabIndex = 19;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -475,22 +462,20 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 534);
-            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(6, 370);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 99);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 66);
             this.calculatedRunsTextBox.TabIndex = 32;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // calculateNextRunsButton
             // 
             this.calculateNextRunsButton.Enabled = false;
-            this.calculateNextRunsButton.Location = new System.Drawing.Point(9, 485);
-            this.calculateNextRunsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.calculateNextRunsButton.Location = new System.Drawing.Point(6, 338);
             this.calculateNextRunsButton.Name = "calculateNextRunsButton";
-            this.calculateNextRunsButton.Size = new System.Drawing.Size(327, 35);
+            this.calculateNextRunsButton.Size = new System.Drawing.Size(218, 23);
             this.calculateNextRunsButton.TabIndex = 18;
             this.calculateNextRunsButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Calculate_next_100_runs_of_cron_trigger;
             this.calculateNextRunsButton.UseVisualStyleBackColor = true;
@@ -499,10 +484,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 454);
-            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 318);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
             this.cronDocsLinkLabel.TabIndex = 30;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -512,19 +496,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.triggerTypePanel.Controls.Add(this.cronTriggerRadioButton);
             this.triggerTypePanel.Controls.Add(this.simpleTriggerRadioButton);
-            this.triggerTypePanel.Location = new System.Drawing.Point(14, 69);
-            this.triggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.triggerTypePanel.Location = new System.Drawing.Point(9, 68);
             this.triggerTypePanel.Name = "triggerTypePanel";
-            this.triggerTypePanel.Size = new System.Drawing.Size(321, 37);
+            this.triggerTypePanel.Size = new System.Drawing.Size(214, 24);
             this.triggerTypePanel.TabIndex = 29;
             // 
             // cronTriggerRadioButton
             // 
             this.cronTriggerRadioButton.AutoSize = true;
-            this.cronTriggerRadioButton.Location = new System.Drawing.Point(194, 8);
-            this.cronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronTriggerRadioButton.Location = new System.Drawing.Point(129, 5);
             this.cronTriggerRadioButton.Name = "cronTriggerRadioButton";
-            this.cronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
+            this.cronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
             this.cronTriggerRadioButton.TabIndex = 16;
             this.cronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.cronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -534,10 +516,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.simpleTriggerRadioButton.AutoSize = true;
             this.simpleTriggerRadioButton.Checked = true;
-            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.simpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
             this.simpleTriggerRadioButton.Name = "simpleTriggerRadioButton";
-            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
+            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
             this.simpleTriggerRadioButton.TabIndex = 15;
             this.simpleTriggerRadioButton.TabStop = true;
             this.simpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -546,10 +527,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(9, 422);
-            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.buildCronLabel.Location = new System.Drawing.Point(6, 297);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
+            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
             this.buildCronLabel.TabIndex = 26;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -557,11 +537,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 178);
-            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 139);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(312, 238);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(208, 155);
             this.cronTriggerInfoTextBox.TabIndex = 25;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -569,10 +548,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(186, 422);
-            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(124, 297);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
             this.cronmakerLinkLabel.TabIndex = 24;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -581,30 +559,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronExpressionLabel
             // 
             this.cronExpressionLabel.AutoSize = true;
-            this.cronExpressionLabel.Location = new System.Drawing.Point(9, 114);
-            this.cronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronExpressionLabel.Location = new System.Drawing.Point(6, 97);
             this.cronExpressionLabel.Name = "cronExpressionLabel";
-            this.cronExpressionLabel.Size = new System.Drawing.Size(123, 20);
+            this.cronExpressionLabel.Size = new System.Drawing.Size(82, 13);
             this.cronExpressionLabel.TabIndex = 23;
             this.cronExpressionLabel.Text = "Cron expression";
             // 
             // cronExpressionTextBox
             // 
             this.cronExpressionTextBox.Enabled = false;
-            this.cronExpressionTextBox.Location = new System.Drawing.Point(14, 138);
-            this.cronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronExpressionTextBox.Location = new System.Drawing.Point(9, 113);
             this.cronExpressionTextBox.Name = "cronExpressionTextBox";
-            this.cronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
+            this.cronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
             this.cronExpressionTextBox.TabIndex = 17;
             this.cronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // minutesLabel
             // 
             this.minutesLabel.AutoSize = true;
-            this.minutesLabel.Location = new System.Drawing.Point(96, 34);
+            this.minutesLabel.Location = new System.Drawing.Point(64, 45);
             this.minutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.minutesLabel.Name = "minutesLabel";
-            this.minutesLabel.Size = new System.Drawing.Size(26, 20);
+            this.minutesLabel.Size = new System.Drawing.Size(19, 13);
             this.minutesLabel.TabIndex = 5;
             this.minutesLabel.Text = "M:";
             this.minutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -612,10 +588,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // hoursLabel
             // 
             this.hoursLabel.AutoSize = true;
-            this.hoursLabel.Location = new System.Drawing.Point(9, 34);
+            this.hoursLabel.Location = new System.Drawing.Point(6, 45);
             this.hoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.hoursLabel.Name = "hoursLabel";
-            this.hoursLabel.Size = new System.Drawing.Size(25, 20);
+            this.hoursLabel.Size = new System.Drawing.Size(18, 13);
             this.hoursLabel.TabIndex = 4;
             this.hoursLabel.Text = "H:";
             this.hoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -623,10 +599,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // startAtLabel
             // 
             this.startAtLabel.AutoSize = true;
-            this.startAtLabel.Location = new System.Drawing.Point(189, 34);
-            this.startAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.startAtLabel.Location = new System.Drawing.Point(126, 45);
             this.startAtLabel.Name = "startAtLabel";
-            this.startAtLabel.Size = new System.Drawing.Size(59, 20);
+            this.startAtLabel.Size = new System.Drawing.Size(39, 13);
             this.startAtLabel.TabIndex = 3;
             this.startAtLabel.Text = "start at";
             this.startAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -635,11 +610,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.startAtDateTimePicker.CustomFormat = "HH:mm";
             this.startAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.startAtDateTimePicker.Location = new System.Drawing.Point(248, 29);
-            this.startAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.startAtDateTimePicker.Location = new System.Drawing.Point(165, 42);
             this.startAtDateTimePicker.Name = "startAtDateTimePicker";
             this.startAtDateTimePicker.ShowUpDown = true;
-            this.startAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
+            this.startAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
             this.startAtDateTimePicker.TabIndex = 14;
             this.startAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -647,11 +621,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.minutesDateTimePicker.CustomFormat = "mm";
             this.minutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.minutesDateTimePicker.Location = new System.Drawing.Point(124, 29);
-            this.minutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.minutesDateTimePicker.Location = new System.Drawing.Point(83, 42);
             this.minutesDateTimePicker.Name = "minutesDateTimePicker";
             this.minutesDateTimePicker.ShowUpDown = true;
-            this.minutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.minutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.minutesDateTimePicker.TabIndex = 13;
             this.minutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -659,11 +632,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.hoursDateTimePicker.CustomFormat = "HH";
             this.hoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.hoursDateTimePicker.Location = new System.Drawing.Point(36, 29);
-            this.hoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.hoursDateTimePicker.Location = new System.Drawing.Point(24, 42);
             this.hoursDateTimePicker.Name = "hoursDateTimePicker";
             this.hoursDateTimePicker.ShowUpDown = true;
-            this.hoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.hoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.hoursDateTimePicker.TabIndex = 12;
             this.hoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -674,10 +646,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.bottomToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.cancelButton,
             this.addJobButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 812);
+            this.bottomToolStrip.Location = new System.Drawing.Point(0, 535);
             this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Padding = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.bottomToolStrip.Size = new System.Drawing.Size(728, 32);
+            this.bottomToolStrip.Size = new System.Drawing.Size(489, 25);
             this.bottomToolStrip.TabIndex = 3;
             this.bottomToolStrip.Text = "toolStrip1";
             // 
@@ -687,7 +658,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(67, 29);
+            this.cancelButton.Size = new System.Drawing.Size(47, 22);
             this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
             this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
             // 
@@ -697,7 +668,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(146, 29);
+            this.addJobButton.Size = new System.Drawing.Size(97, 22);
             this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
             this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
             // 
@@ -707,26 +678,23 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(372, 697);
-            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(248, 471);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 103);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 67);
             this.retryPolicyGroupBox.TabIndex = 7;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(150, 65);
-            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(100, 42);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesDelayUpDown.TabIndex = 7;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -736,15 +704,14 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(150, 28);
-            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(100, 18);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesCountUpDown.TabIndex = 6;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -755,29 +722,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 68);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(7, 44);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(123, 20);
+            this.label2.Size = new System.Drawing.Size(83, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(10, 31);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(7, 20);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(131, 20);
+            this.label1.Size = new System.Drawing.Size(87, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(20, 737);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(13, 479);
+            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 107);
+            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 70);
             this.groupBoxExceptions.TabIndex = 10;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -787,19 +754,20 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(13, 26);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
+            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
             // DownloadJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(728, 844);
+            this.ClientSize = new System.Drawing.Size(489, 560);
             this.Controls.Add(this.bottomToolStrip);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.retryPolicyGroupBox);
@@ -807,11 +775,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.Controls.Add(this.axDetailsGroupBox);
             this.Controls.Add(this.jobDetailsGroupBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(750, 900);
+            this.MaximumSize = new System.Drawing.Size(505, 599);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(750, 900);
+            this.MinimumSize = new System.Drawing.Size(505, 599);
             this.Name = "DownloadJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -902,5 +869,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.NumericUpDown retriesCountUpDown;
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
+        private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
     }
 }

--- a/Scheduler/Forms/DownloadJob.Designer.cs
+++ b/Scheduler/Forms/DownloadJob.Designer.cs
@@ -81,9 +81,6 @@ namespace RecurringIntegrationsScheduler.Forms
             this.startAtDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.minutesDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.hoursDateTimePicker = new System.Windows.Forms.DateTimePicker();
-            this.bottomToolStrip = new System.Windows.Forms.ToolStrip();
-            this.cancelButton = new System.Windows.Forms.ToolStripButton();
-            this.addJobButton = new System.Windows.Forms.ToolStripButton();
             this.retryPolicyGroupBox = new System.Windows.Forms.GroupBox();
             this.retriesDelayUpDown = new System.Windows.Forms.NumericUpDown();
             this.retriesCountUpDown = new System.Windows.Forms.NumericUpDown();
@@ -91,16 +88,19 @@ namespace RecurringIntegrationsScheduler.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.groupBoxExceptions = new System.Windows.Forms.GroupBox();
             this.pauseOnExceptionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.groupBoxButtons = new System.Windows.Forms.GroupBox();
+            this.addJobButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
             this.jobDetailsGroupBox.SuspendLayout();
             this.axDetailsGroupBox.SuspendLayout();
             this.authMethodPanel.SuspendLayout();
             this.recurrenceGroupBox.SuspendLayout();
             this.triggerTypePanel.SuspendLayout();
-            this.bottomToolStrip.SuspendLayout();
             this.retryPolicyGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.retriesDelayUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).BeginInit();
             this.groupBoxExceptions.SuspendLayout();
+            this.groupBoxButtons.SuspendLayout();
             this.SuspendLayout();
             // 
             // jobDetailsGroupBox
@@ -121,9 +121,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
+            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(230, 301);
+            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(345, 463);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -132,10 +134,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.deletePackageCheckBox.AutoSize = true;
             this.deletePackageCheckBox.Enabled = false;
-            this.deletePackageCheckBox.Location = new System.Drawing.Point(12, 276);
-            this.deletePackageCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.deletePackageCheckBox.Location = new System.Drawing.Point(18, 425);
             this.deletePackageCheckBox.Name = "deletePackageCheckBox";
-            this.deletePackageCheckBox.Size = new System.Drawing.Size(118, 17);
+            this.deletePackageCheckBox.Size = new System.Drawing.Size(171, 24);
             this.deletePackageCheckBox.TabIndex = 14;
             this.deletePackageCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Delete_package_file;
             this.deletePackageCheckBox.UseVisualStyleBackColor = true;
@@ -144,10 +145,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.addTimestampCheckBox.AutoSize = true;
             this.addTimestampCheckBox.Enabled = false;
-            this.addTimestampCheckBox.Location = new System.Drawing.Point(12, 256);
-            this.addTimestampCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.addTimestampCheckBox.Location = new System.Drawing.Point(18, 394);
             this.addTimestampCheckBox.Name = "addTimestampCheckBox";
-            this.addTimestampCheckBox.Size = new System.Drawing.Size(177, 17);
+            this.addTimestampCheckBox.Size = new System.Drawing.Size(260, 24);
             this.addTimestampCheckBox.TabIndex = 13;
             this.addTimestampCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Make_exported_file_name_unique;
             this.addTimestampCheckBox.UseVisualStyleBackColor = true;
@@ -155,10 +155,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // unzipCheckBox
             // 
             this.unzipCheckBox.AutoSize = true;
-            this.unzipCheckBox.Location = new System.Drawing.Point(12, 236);
-            this.unzipCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.unzipCheckBox.Location = new System.Drawing.Point(18, 363);
             this.unzipCheckBox.Name = "unzipCheckBox";
-            this.unzipCheckBox.Size = new System.Drawing.Size(114, 17);
+            this.unzipCheckBox.Size = new System.Drawing.Size(165, 24);
             this.unzipCheckBox.TabIndex = 12;
             this.unzipCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Unzip_package_file;
             this.unzipCheckBox.UseVisualStyleBackColor = true;
@@ -169,9 +168,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(12, 172);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(18, 265);
+            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(143, 17);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(213, 24);
             this.useStandardSubfolder.TabIndex = 8;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_folder_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -182,10 +182,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.errorsFolderBrowserButton.Enabled = false;
             this.errorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.errorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(202, 206);
+            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(303, 317);
             this.errorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.errorsFolderBrowserButton.Name = "errorsFolderBrowserButton";
-            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.errorsFolderBrowserButton.TabIndex = 7;
             this.errorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.errorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -194,17 +194,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // errorsFolder
             // 
             this.errorsFolder.Enabled = false;
-            this.errorsFolder.Location = new System.Drawing.Point(12, 210);
+            this.errorsFolder.Location = new System.Drawing.Point(18, 323);
+            this.errorsFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.errorsFolder.Name = "errorsFolder";
-            this.errorsFolder.Size = new System.Drawing.Size(187, 20);
+            this.errorsFolder.Size = new System.Drawing.Size(278, 26);
             this.errorsFolder.TabIndex = 6;
             // 
             // errorsFolderLabel
             // 
             this.errorsFolderLabel.AutoSize = true;
-            this.errorsFolderLabel.Location = new System.Drawing.Point(9, 193);
+            this.errorsFolderLabel.Location = new System.Drawing.Point(14, 297);
+            this.errorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.errorsFolderLabel.Name = "errorsFolderLabel";
-            this.errorsFolderLabel.Size = new System.Drawing.Size(63, 13);
+            this.errorsFolderLabel.Size = new System.Drawing.Size(96, 20);
             this.errorsFolderLabel.TabIndex = 11;
             this.errorsFolderLabel.Text = "Errors folder";
             // 
@@ -212,10 +214,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.downloadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.downloadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(202, 144);
+            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(303, 222);
             this.downloadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.downloadFolderBrowserButton.Name = "downloadFolderBrowserButton";
-            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.downloadFolderBrowserButton.TabIndex = 5;
             this.downloadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.downloadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -223,35 +225,39 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // downloadFolder
             // 
-            this.downloadFolder.Location = new System.Drawing.Point(13, 147);
+            this.downloadFolder.Location = new System.Drawing.Point(20, 226);
+            this.downloadFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.downloadFolder.Name = "downloadFolder";
-            this.downloadFolder.Size = new System.Drawing.Size(187, 20);
+            this.downloadFolder.Size = new System.Drawing.Size(278, 26);
             this.downloadFolder.TabIndex = 4;
             this.downloadFolder.TextChanged += new System.EventHandler(this.DownloadFolder_TextChanged);
             // 
             // downloadFolderLabel
             // 
             this.downloadFolderLabel.AutoSize = true;
-            this.downloadFolderLabel.Location = new System.Drawing.Point(10, 130);
+            this.downloadFolderLabel.Location = new System.Drawing.Point(15, 200);
+            this.downloadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.downloadFolderLabel.Name = "downloadFolderLabel";
-            this.downloadFolderLabel.Size = new System.Drawing.Size(84, 13);
+            this.downloadFolderLabel.Size = new System.Drawing.Size(124, 20);
             this.downloadFolderLabel.TabIndex = 8;
             this.downloadFolderLabel.Text = "Download folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(11, 91);
+            this.jobDescription.Location = new System.Drawing.Point(16, 140);
+            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(211, 35);
+            this.jobDescription.Size = new System.Drawing.Size(314, 52);
             this.jobDescription.TabIndex = 3;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(9, 74);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(14, 114);
+            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
             this.jobDescriptionLabel.TabIndex = 4;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -259,34 +265,38 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
+            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 2;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(9, 52);
+            this.jobGroupLabel.Location = new System.Drawing.Point(14, 80);
+            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
+            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
             this.jobGroupLabel.TabIndex = 2;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(50, 17);
+            this.jobName.Location = new System.Drawing.Point(75, 26);
+            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(173, 20);
+            this.jobName.Size = new System.Drawing.Size(258, 26);
             this.jobName.TabIndex = 1;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(9, 20);
+            this.jobNameLabel.Location = new System.Drawing.Point(14, 31);
+            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
+            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -301,9 +311,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(13, 320);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(20, 492);
+            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 154);
+            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 237);
             this.axDetailsGroupBox.TabIndex = 1;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -311,9 +323,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(9, 103);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(14, 158);
+            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
             this.aadApplicationLabel.TabIndex = 34;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -321,26 +334,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(106, 101);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(159, 155);
+            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(117, 21);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(174, 28);
             this.aadApplicationComboBox.TabIndex = 33;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(8, 69);
+            this.authMethodPanel.Location = new System.Drawing.Point(12, 106);
+            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(214, 25);
+            this.authMethodPanel.Size = new System.Drawing.Size(321, 38);
             this.authMethodPanel.TabIndex = 31;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
+            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
             this.serviceAuthRadioButton.TabIndex = 16;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -350,9 +366,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
             this.userAuthRadioButton.TabIndex = 15;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -361,9 +378,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // dataJobLabel
             // 
             this.dataJobLabel.AutoSize = true;
-            this.dataJobLabel.Location = new System.Drawing.Point(20, 46);
+            this.dataJobLabel.Location = new System.Drawing.Point(30, 71);
+            this.dataJobLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.dataJobLabel.Name = "dataJobLabel";
-            this.dataJobLabel.Size = new System.Drawing.Size(47, 13);
+            this.dataJobLabel.Size = new System.Drawing.Size(69, 20);
             this.dataJobLabel.TabIndex = 22;
             this.dataJobLabel.Text = "Data job";
             // 
@@ -371,17 +389,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.dataJobComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.dataJobComboBox.FormattingEnabled = true;
-            this.dataJobComboBox.Location = new System.Drawing.Point(76, 43);
+            this.dataJobComboBox.Location = new System.Drawing.Point(114, 66);
+            this.dataJobComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.dataJobComboBox.Name = "dataJobComboBox";
-            this.dataJobComboBox.Size = new System.Drawing.Size(147, 21);
+            this.dataJobComboBox.Size = new System.Drawing.Size(218, 28);
             this.dataJobComboBox.TabIndex = 11;
             // 
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(65, 129);
+            this.userLabel.Location = new System.Drawing.Point(98, 198);
+            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(29, 13);
+            this.userLabel.Size = new System.Drawing.Size(43, 20);
             this.userLabel.TabIndex = 19;
             this.userLabel.Text = "User";
             // 
@@ -389,17 +409,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(106, 127);
+            this.userComboBox.Location = new System.Drawing.Point(159, 195);
+            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(117, 21);
+            this.userComboBox.Size = new System.Drawing.Size(174, 28);
             this.userComboBox.TabIndex = 10;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(20, 20);
+            this.instanceLabel.Location = new System.Drawing.Point(30, 31);
+            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
+            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
             this.instanceLabel.TabIndex = 16;
             this.instanceLabel.Text = "Instance";
             // 
@@ -407,9 +429,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(76, 17);
+            this.instanceComboBox.Location = new System.Drawing.Point(114, 26);
+            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
+            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
             this.instanceComboBox.TabIndex = 9;
             // 
             // recurrenceGroupBox
@@ -431,9 +454,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.startAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.minutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.hoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(248, 13);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(372, 20);
+            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 455);
+            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 700);
             this.recurrenceGroupBox.TabIndex = 2;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
@@ -441,19 +466,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // pauseIndefinitelyCheckBox
             // 
             this.pauseIndefinitelyCheckBox.AutoSize = true;
-            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(9, 20);
-            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(14, 31);
             this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
-            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(183, 24);
             this.pauseIndefinitelyCheckBox.TabIndex = 0;
             this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
             this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
             // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(158, 370);
+            this.moreExamplesButton.Location = new System.Drawing.Point(237, 569);
+            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(66, 66);
+            this.moreExamplesButton.Size = new System.Drawing.Size(99, 102);
             this.moreExamplesButton.TabIndex = 19;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -462,20 +487,22 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(6, 370);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 569);
+            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 66);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 99);
             this.calculatedRunsTextBox.TabIndex = 32;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // calculateNextRunsButton
             // 
             this.calculateNextRunsButton.Enabled = false;
-            this.calculateNextRunsButton.Location = new System.Drawing.Point(6, 338);
+            this.calculateNextRunsButton.Location = new System.Drawing.Point(9, 520);
+            this.calculateNextRunsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.calculateNextRunsButton.Name = "calculateNextRunsButton";
-            this.calculateNextRunsButton.Size = new System.Drawing.Size(218, 23);
+            this.calculateNextRunsButton.Size = new System.Drawing.Size(327, 35);
             this.calculateNextRunsButton.TabIndex = 18;
             this.calculateNextRunsButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Calculate_next_100_runs_of_cron_trigger;
             this.calculateNextRunsButton.UseVisualStyleBackColor = true;
@@ -484,9 +511,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 318);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 489);
+            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
             this.cronDocsLinkLabel.TabIndex = 30;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -496,17 +524,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.triggerTypePanel.Controls.Add(this.cronTriggerRadioButton);
             this.triggerTypePanel.Controls.Add(this.simpleTriggerRadioButton);
-            this.triggerTypePanel.Location = new System.Drawing.Point(9, 68);
+            this.triggerTypePanel.Location = new System.Drawing.Point(14, 105);
+            this.triggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.triggerTypePanel.Name = "triggerTypePanel";
-            this.triggerTypePanel.Size = new System.Drawing.Size(214, 24);
+            this.triggerTypePanel.Size = new System.Drawing.Size(321, 37);
             this.triggerTypePanel.TabIndex = 29;
             // 
             // cronTriggerRadioButton
             // 
             this.cronTriggerRadioButton.AutoSize = true;
-            this.cronTriggerRadioButton.Location = new System.Drawing.Point(129, 5);
+            this.cronTriggerRadioButton.Location = new System.Drawing.Point(194, 8);
+            this.cronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronTriggerRadioButton.Name = "cronTriggerRadioButton";
-            this.cronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
+            this.cronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
             this.cronTriggerRadioButton.TabIndex = 16;
             this.cronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.cronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -516,9 +546,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.simpleTriggerRadioButton.AutoSize = true;
             this.simpleTriggerRadioButton.Checked = true;
-            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.simpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.simpleTriggerRadioButton.Name = "simpleTriggerRadioButton";
-            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
+            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
             this.simpleTriggerRadioButton.TabIndex = 15;
             this.simpleTriggerRadioButton.TabStop = true;
             this.simpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -527,9 +558,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(6, 297);
+            this.buildCronLabel.Location = new System.Drawing.Point(9, 457);
+            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
+            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
             this.buildCronLabel.TabIndex = 26;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -537,10 +569,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 139);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 214);
+            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(208, 155);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(312, 238);
             this.cronTriggerInfoTextBox.TabIndex = 25;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -548,9 +581,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(124, 297);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(186, 457);
+            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
             this.cronmakerLinkLabel.TabIndex = 24;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -559,28 +593,30 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronExpressionLabel
             // 
             this.cronExpressionLabel.AutoSize = true;
-            this.cronExpressionLabel.Location = new System.Drawing.Point(6, 97);
+            this.cronExpressionLabel.Location = new System.Drawing.Point(9, 149);
+            this.cronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronExpressionLabel.Name = "cronExpressionLabel";
-            this.cronExpressionLabel.Size = new System.Drawing.Size(82, 13);
+            this.cronExpressionLabel.Size = new System.Drawing.Size(123, 20);
             this.cronExpressionLabel.TabIndex = 23;
             this.cronExpressionLabel.Text = "Cron expression";
             // 
             // cronExpressionTextBox
             // 
             this.cronExpressionTextBox.Enabled = false;
-            this.cronExpressionTextBox.Location = new System.Drawing.Point(9, 113);
+            this.cronExpressionTextBox.Location = new System.Drawing.Point(14, 174);
+            this.cronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronExpressionTextBox.Name = "cronExpressionTextBox";
-            this.cronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
+            this.cronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
             this.cronExpressionTextBox.TabIndex = 17;
             this.cronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // minutesLabel
             // 
             this.minutesLabel.AutoSize = true;
-            this.minutesLabel.Location = new System.Drawing.Point(64, 45);
+            this.minutesLabel.Location = new System.Drawing.Point(96, 69);
             this.minutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.minutesLabel.Name = "minutesLabel";
-            this.minutesLabel.Size = new System.Drawing.Size(19, 13);
+            this.minutesLabel.Size = new System.Drawing.Size(26, 20);
             this.minutesLabel.TabIndex = 5;
             this.minutesLabel.Text = "M:";
             this.minutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -588,10 +624,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // hoursLabel
             // 
             this.hoursLabel.AutoSize = true;
-            this.hoursLabel.Location = new System.Drawing.Point(6, 45);
+            this.hoursLabel.Location = new System.Drawing.Point(9, 69);
             this.hoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.hoursLabel.Name = "hoursLabel";
-            this.hoursLabel.Size = new System.Drawing.Size(18, 13);
+            this.hoursLabel.Size = new System.Drawing.Size(25, 20);
             this.hoursLabel.TabIndex = 4;
             this.hoursLabel.Text = "H:";
             this.hoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -599,9 +635,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // startAtLabel
             // 
             this.startAtLabel.AutoSize = true;
-            this.startAtLabel.Location = new System.Drawing.Point(126, 45);
+            this.startAtLabel.Location = new System.Drawing.Point(189, 69);
+            this.startAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.startAtLabel.Name = "startAtLabel";
-            this.startAtLabel.Size = new System.Drawing.Size(39, 13);
+            this.startAtLabel.Size = new System.Drawing.Size(59, 20);
             this.startAtLabel.TabIndex = 3;
             this.startAtLabel.Text = "start at";
             this.startAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -610,10 +647,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.startAtDateTimePicker.CustomFormat = "HH:mm";
             this.startAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.startAtDateTimePicker.Location = new System.Drawing.Point(165, 42);
+            this.startAtDateTimePicker.Location = new System.Drawing.Point(248, 65);
+            this.startAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.startAtDateTimePicker.Name = "startAtDateTimePicker";
             this.startAtDateTimePicker.ShowUpDown = true;
-            this.startAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
+            this.startAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
             this.startAtDateTimePicker.TabIndex = 14;
             this.startAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -621,10 +659,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.minutesDateTimePicker.CustomFormat = "mm";
             this.minutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.minutesDateTimePicker.Location = new System.Drawing.Point(83, 42);
+            this.minutesDateTimePicker.Location = new System.Drawing.Point(124, 65);
+            this.minutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.minutesDateTimePicker.Name = "minutesDateTimePicker";
             this.minutesDateTimePicker.ShowUpDown = true;
-            this.minutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.minutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.minutesDateTimePicker.TabIndex = 13;
             this.minutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -632,45 +671,13 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.hoursDateTimePicker.CustomFormat = "HH";
             this.hoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.hoursDateTimePicker.Location = new System.Drawing.Point(24, 42);
+            this.hoursDateTimePicker.Location = new System.Drawing.Point(36, 65);
+            this.hoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.hoursDateTimePicker.Name = "hoursDateTimePicker";
             this.hoursDateTimePicker.ShowUpDown = true;
-            this.hoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.hoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.hoursDateTimePicker.TabIndex = 12;
             this.hoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
-            // 
-            // bottomToolStrip
-            // 
-            this.bottomToolStrip.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.bottomToolStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.bottomToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cancelButton,
-            this.addJobButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 535);
-            this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Size = new System.Drawing.Size(489, 25);
-            this.bottomToolStrip.TabIndex = 3;
-            this.bottomToolStrip.Text = "toolStrip1";
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(47, 22);
-            this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
-            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
-            // 
-            // addJobButton
-            // 
-            this.addJobButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(97, 22);
-            this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
-            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
             // 
             // retryPolicyGroupBox
             // 
@@ -678,23 +685,26 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(248, 471);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(372, 725);
+            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 67);
+            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 103);
             this.retryPolicyGroupBox.TabIndex = 7;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(100, 42);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(150, 65);
+            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesDelayUpDown.TabIndex = 7;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -704,14 +714,15 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(100, 18);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(150, 28);
+            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesCountUpDown.TabIndex = 6;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -722,29 +733,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(7, 44);
+            this.label2.Location = new System.Drawing.Point(10, 68);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 13);
+            this.label2.Size = new System.Drawing.Size(123, 20);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(7, 20);
+            this.label1.Location = new System.Drawing.Point(10, 31);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(87, 13);
+            this.label1.Size = new System.Drawing.Size(131, 20);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(13, 479);
-            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(20, 737);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 70);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 91);
             this.groupBoxExceptions.TabIndex = 10;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -754,31 +765,60 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
-            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(14, 26);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
+            // groupBoxButtons
+            // 
+            this.groupBoxButtons.Controls.Add(this.addJobButton);
+            this.groupBoxButtons.Controls.Add(this.cancelButton);
+            this.groupBoxButtons.Location = new System.Drawing.Point(20, 836);
+            this.groupBoxButtons.Name = "groupBoxButtons";
+            this.groupBoxButtons.Size = new System.Drawing.Size(697, 74);
+            this.groupBoxButtons.TabIndex = 11;
+            this.groupBoxButtons.TabStop = false;
+            // 
+            // addJobButton
+            // 
+            this.addJobButton.Location = new System.Drawing.Point(352, 25);
+            this.addJobButton.Name = "addJobButton";
+            this.addJobButton.Size = new System.Drawing.Size(162, 34);
+            this.addJobButton.TabIndex = 2;
+            this.addJobButton.Text = "Add to schedule";
+            this.addJobButton.UseVisualStyleBackColor = true;
+            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.Location = new System.Drawing.Point(529, 25);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(162, 34);
+            this.cancelButton.TabIndex = 1;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
+            // 
             // DownloadJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(489, 560);
-            this.Controls.Add(this.bottomToolStrip);
+            this.ClientSize = new System.Drawing.Size(724, 920);
+            this.Controls.Add(this.groupBoxButtons);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.retryPolicyGroupBox);
             this.Controls.Add(this.recurrenceGroupBox);
             this.Controls.Add(this.axDetailsGroupBox);
             this.Controls.Add(this.jobDetailsGroupBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(505, 599);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(505, 599);
+            this.MinimumSize = new System.Drawing.Size(746, 891);
             this.Name = "DownloadJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -795,16 +835,14 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.PerformLayout();
             this.triggerTypePanel.ResumeLayout(false);
             this.triggerTypePanel.PerformLayout();
-            this.bottomToolStrip.ResumeLayout(false);
-            this.bottomToolStrip.PerformLayout();
             this.retryPolicyGroupBox.ResumeLayout(false);
             this.retryPolicyGroupBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.retriesDelayUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).EndInit();
             this.groupBoxExceptions.ResumeLayout(false);
             this.groupBoxExceptions.PerformLayout();
+            this.groupBoxButtons.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -847,13 +885,10 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.Panel triggerTypePanel;
         private System.Windows.Forms.RadioButton cronTriggerRadioButton;
         private System.Windows.Forms.RadioButton simpleTriggerRadioButton;
-        private System.Windows.Forms.ToolStrip bottomToolStrip;
         private System.Windows.Forms.LinkLabel cronDocsLinkLabel;
         private System.Windows.Forms.TextBox calculatedRunsTextBox;
         private System.Windows.Forms.Button calculateNextRunsButton;
         private System.Windows.Forms.Button moreExamplesButton;
-        private System.Windows.Forms.ToolStripButton cancelButton;
-        private System.Windows.Forms.ToolStripButton addJobButton;
         private System.Windows.Forms.CheckBox addTimestampCheckBox;
         private System.Windows.Forms.CheckBox unzipCheckBox;
         private System.Windows.Forms.CheckBox deletePackageCheckBox;
@@ -870,5 +905,8 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
         private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
+        private System.Windows.Forms.GroupBox groupBoxButtons;
+        private System.Windows.Forms.Button addJobButton;
+        private System.Windows.Forms.Button cancelButton;
     }
 }

--- a/Scheduler/Forms/DownloadJob.cs
+++ b/Scheduler/Forms/DownloadJob.cs
@@ -208,6 +208,10 @@ namespace RecurringIntegrationsScheduler.Forms
                 }
                 instanceComboBox.SelectedItem = axInstance;
 
+                pauseIndefinitelyCheckBox.Checked =
+                    (JobDetail.JobDataMap[SettingsConstants.IndefinitePause] != null) &&
+                    Convert.ToBoolean(JobDetail.JobDataMap[SettingsConstants.IndefinitePause].ToString());
+
                 if (Trigger.GetType() == typeof(SimpleTriggerImpl))
                 {
                     var localTrigger = (SimpleTriggerImpl) Trigger;
@@ -404,7 +408,8 @@ namespace RecurringIntegrationsScheduler.Forms
                 {SettingsConstants.DeletePackage, deletePackageCheckBox.Checked.ToString()},
                 {SettingsConstants.RetryCount, retriesCountUpDown.Value.ToString(CultureInfo.InvariantCulture)},
                 {SettingsConstants.RetryDelay, retriesDelayUpDown.Value.ToString(CultureInfo.InvariantCulture)},
-                {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()}
+                {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()},
+                {SettingsConstants.IndefinitePause, pauseIndefinitelyCheckBox.Checked.ToString()}
             };
             if (serviceAuthRadioButton.Checked)
             {

--- a/Scheduler/Forms/DownloadJob.resx
+++ b/Scheduler/Forms/DownloadJob.resx
@@ -125,7 +125,4 @@
 
 Default example above means: Each working day of the week (MON-FRI) run every 15 minutes (0/15) between 8:00 and 18:45 (8-18 - last run will be at 18:45)</value>
   </data>
-  <metadata name="bottomToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>245, 17</value>
-  </metadata>
 </root>

--- a/Scheduler/Forms/ExportJob.Designer.cs
+++ b/Scheduler/Forms/ExportJob.Designer.cs
@@ -95,6 +95,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.groupBoxExceptions = new System.Windows.Forms.GroupBox();
             this.pauseOnExceptionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
             this.jobDetailsGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.interval)).BeginInit();
             this.axDetailsGroupBox.SuspendLayout();
@@ -132,11 +133,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
-            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(345, 600);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(230, 390);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -145,10 +144,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.addTimestampCheckBox.AutoSize = true;
             this.addTimestampCheckBox.Enabled = false;
-            this.addTimestampCheckBox.Location = new System.Drawing.Point(16, 394);
-            this.addTimestampCheckBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.addTimestampCheckBox.Location = new System.Drawing.Point(11, 256);
+            this.addTimestampCheckBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.addTimestampCheckBox.Name = "addTimestampCheckBox";
-            this.addTimestampCheckBox.Size = new System.Drawing.Size(260, 24);
+            this.addTimestampCheckBox.Size = new System.Drawing.Size(177, 17);
             this.addTimestampCheckBox.TabIndex = 10;
             this.addTimestampCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Make_exported_file_name_unique;
             this.addTimestampCheckBox.UseVisualStyleBackColor = true;
@@ -156,34 +155,32 @@ namespace RecurringIntegrationsScheduler.Forms
             // legalEntityLabel
             // 
             this.legalEntityLabel.AutoSize = true;
-            this.legalEntityLabel.Location = new System.Drawing.Point(15, 500);
-            this.legalEntityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.legalEntityLabel.Location = new System.Drawing.Point(10, 325);
             this.legalEntityLabel.Name = "legalEntityLabel";
-            this.legalEntityLabel.Size = new System.Drawing.Size(90, 20);
+            this.legalEntityLabel.Size = new System.Drawing.Size(61, 13);
             this.legalEntityLabel.TabIndex = 22;
             this.legalEntityLabel.Text = "Legal entity";
             // 
             // legalEntity
             // 
-            this.legalEntity.Location = new System.Drawing.Point(120, 497);
-            this.legalEntity.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.legalEntity.Location = new System.Drawing.Point(80, 323);
             this.legalEntity.Name = "legalEntity";
-            this.legalEntity.Size = new System.Drawing.Size(96, 26);
+            this.legalEntity.Size = new System.Drawing.Size(65, 20);
             this.legalEntity.TabIndex = 13;
             // 
             // intervalLabel
             // 
             this.intervalLabel.AutoSize = true;
-            this.intervalLabel.Location = new System.Drawing.Point(15, 538);
-            this.intervalLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.intervalLabel.Location = new System.Drawing.Point(10, 350);
             this.intervalLabel.Name = "intervalLabel";
-            this.intervalLabel.Size = new System.Drawing.Size(199, 20);
+            this.intervalLabel.Size = new System.Drawing.Size(136, 13);
             this.intervalLabel.TabIndex = 20;
             this.intervalLabel.Text = "Status check interval (sec.)";
             // 
             // interval
             // 
-            this.interval.Location = new System.Drawing.Point(220, 537);
+            this.interval.Location = new System.Drawing.Point(147, 349);
+            this.interval.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.interval.Maximum = new decimal(new int[] {
             3600,
             0,
@@ -195,7 +192,7 @@ namespace RecurringIntegrationsScheduler.Forms
             0,
             0});
             this.interval.Name = "interval";
-            this.interval.Size = new System.Drawing.Size(111, 26);
+            this.interval.Size = new System.Drawing.Size(74, 20);
             this.interval.TabIndex = 14;
             this.interval.Value = new decimal(new int[] {
             300,
@@ -206,29 +203,27 @@ namespace RecurringIntegrationsScheduler.Forms
             // dataProjectLabel
             // 
             this.dataProjectLabel.AutoSize = true;
-            this.dataProjectLabel.Location = new System.Drawing.Point(15, 465);
-            this.dataProjectLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.dataProjectLabel.Location = new System.Drawing.Point(10, 302);
             this.dataProjectLabel.Name = "dataProjectLabel";
-            this.dataProjectLabel.Size = new System.Drawing.Size(96, 20);
+            this.dataProjectLabel.Size = new System.Drawing.Size(65, 13);
             this.dataProjectLabel.TabIndex = 16;
             this.dataProjectLabel.Text = "Data project";
             // 
             // dataProject
             // 
-            this.dataProject.Location = new System.Drawing.Point(118, 462);
-            this.dataProject.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.dataProject.Location = new System.Drawing.Point(79, 300);
             this.dataProject.Name = "dataProject";
-            this.dataProject.Size = new System.Drawing.Size(220, 26);
+            this.dataProject.Size = new System.Drawing.Size(148, 20);
             this.dataProject.TabIndex = 12;
             // 
             // deletePackageCheckBox
             // 
             this.deletePackageCheckBox.AutoSize = true;
             this.deletePackageCheckBox.Enabled = false;
-            this.deletePackageCheckBox.Location = new System.Drawing.Point(16, 426);
-            this.deletePackageCheckBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.deletePackageCheckBox.Location = new System.Drawing.Point(11, 277);
+            this.deletePackageCheckBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.deletePackageCheckBox.Name = "deletePackageCheckBox";
-            this.deletePackageCheckBox.Size = new System.Drawing.Size(171, 24);
+            this.deletePackageCheckBox.Size = new System.Drawing.Size(118, 17);
             this.deletePackageCheckBox.TabIndex = 11;
             this.deletePackageCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Delete_package_file;
             this.deletePackageCheckBox.UseVisualStyleBackColor = true;
@@ -236,10 +231,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // unzipCheckBox
             // 
             this.unzipCheckBox.AutoSize = true;
-            this.unzipCheckBox.Location = new System.Drawing.Point(18, 362);
-            this.unzipCheckBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.unzipCheckBox.Location = new System.Drawing.Point(12, 235);
+            this.unzipCheckBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.unzipCheckBox.Name = "unzipCheckBox";
-            this.unzipCheckBox.Size = new System.Drawing.Size(165, 24);
+            this.unzipCheckBox.Size = new System.Drawing.Size(114, 17);
             this.unzipCheckBox.TabIndex = 9;
             this.unzipCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Unzip_package_file;
             this.unzipCheckBox.UseVisualStyleBackColor = true;
@@ -250,10 +245,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(18, 265);
-            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(12, 172);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(213, 24);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(143, 17);
             this.useStandardSubfolder.TabIndex = 6;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_folder_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -264,10 +258,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.errorsFolderBrowserButton.Enabled = false;
             this.errorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.errorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(303, 318);
+            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(202, 207);
             this.errorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.errorsFolderBrowserButton.Name = "errorsFolderBrowserButton";
-            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.errorsFolderBrowserButton.TabIndex = 8;
             this.errorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.errorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -276,19 +270,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // errorsFolder
             // 
             this.errorsFolder.Enabled = false;
-            this.errorsFolder.Location = new System.Drawing.Point(18, 322);
-            this.errorsFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.errorsFolder.Location = new System.Drawing.Point(12, 209);
             this.errorsFolder.Name = "errorsFolder";
-            this.errorsFolder.Size = new System.Drawing.Size(278, 26);
+            this.errorsFolder.Size = new System.Drawing.Size(187, 20);
             this.errorsFolder.TabIndex = 7;
             // 
             // errorsFolderLabel
             // 
             this.errorsFolderLabel.AutoSize = true;
-            this.errorsFolderLabel.Location = new System.Drawing.Point(14, 295);
-            this.errorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.errorsFolderLabel.Location = new System.Drawing.Point(9, 192);
             this.errorsFolderLabel.Name = "errorsFolderLabel";
-            this.errorsFolderLabel.Size = new System.Drawing.Size(96, 20);
+            this.errorsFolderLabel.Size = new System.Drawing.Size(63, 13);
             this.errorsFolderLabel.TabIndex = 11;
             this.errorsFolderLabel.Text = "Errors folder";
             // 
@@ -296,10 +288,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.downloadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.downloadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(303, 222);
+            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(202, 144);
             this.downloadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.downloadFolderBrowserButton.Name = "downloadFolderBrowserButton";
-            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.downloadFolderBrowserButton.TabIndex = 5;
             this.downloadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.downloadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -307,39 +299,35 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // downloadFolder
             // 
-            this.downloadFolder.Location = new System.Drawing.Point(20, 226);
-            this.downloadFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.downloadFolder.Location = new System.Drawing.Point(13, 147);
             this.downloadFolder.Name = "downloadFolder";
-            this.downloadFolder.Size = new System.Drawing.Size(278, 26);
+            this.downloadFolder.Size = new System.Drawing.Size(187, 20);
             this.downloadFolder.TabIndex = 4;
             this.downloadFolder.TextChanged += new System.EventHandler(this.DownloadFolder_TextChanged);
             // 
             // downloadFolderLabel
             // 
             this.downloadFolderLabel.AutoSize = true;
-            this.downloadFolderLabel.Location = new System.Drawing.Point(15, 200);
-            this.downloadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.downloadFolderLabel.Location = new System.Drawing.Point(10, 130);
             this.downloadFolderLabel.Name = "downloadFolderLabel";
-            this.downloadFolderLabel.Size = new System.Drawing.Size(124, 20);
+            this.downloadFolderLabel.Size = new System.Drawing.Size(84, 13);
             this.downloadFolderLabel.TabIndex = 8;
             this.downloadFolderLabel.Text = "Download folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(16, 140);
-            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDescription.Location = new System.Drawing.Point(11, 91);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(314, 52);
+            this.jobDescription.Size = new System.Drawing.Size(211, 35);
             this.jobDescription.TabIndex = 3;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(14, 114);
-            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(9, 74);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
             this.jobDescriptionLabel.TabIndex = 4;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -347,38 +335,34 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
-            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 2;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(14, 80);
-            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobGroupLabel.Location = new System.Drawing.Point(9, 52);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
+            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
             this.jobGroupLabel.TabIndex = 2;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(75, 26);
-            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobName.Location = new System.Drawing.Point(50, 17);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(258, 26);
+            this.jobName.Size = new System.Drawing.Size(173, 20);
             this.jobName.TabIndex = 1;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(14, 31);
-            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobNameLabel.Location = new System.Drawing.Point(9, 20);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
+            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -391,11 +375,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(370, 20);
-            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(247, 13);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 195);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 127);
             this.axDetailsGroupBox.TabIndex = 1;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -403,10 +385,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(14, 120);
-            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(9, 78);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
             this.aadApplicationLabel.TabIndex = 34;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -414,29 +395,26 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(154, 115);
-            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(103, 75);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(180, 28);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(121, 21);
             this.aadApplicationComboBox.TabIndex = 17;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(12, 68);
-            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.authMethodPanel.Location = new System.Drawing.Point(8, 44);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(322, 38);
+            this.authMethodPanel.Size = new System.Drawing.Size(215, 25);
             this.authMethodPanel.TabIndex = 31;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
-            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
             this.serviceAuthRadioButton.TabIndex = 16;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -446,10 +424,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
             this.userAuthRadioButton.TabIndex = 15;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -458,10 +435,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(93, 160);
-            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.userLabel.Location = new System.Drawing.Point(62, 104);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(43, 20);
+            this.userLabel.Size = new System.Drawing.Size(29, 13);
             this.userLabel.TabIndex = 19;
             this.userLabel.Text = "User";
             // 
@@ -469,19 +445,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(154, 155);
-            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userComboBox.Location = new System.Drawing.Point(103, 101);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(180, 28);
+            this.userComboBox.Size = new System.Drawing.Size(121, 21);
             this.userComboBox.TabIndex = 18;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(28, 31);
-            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.instanceLabel.Location = new System.Drawing.Point(19, 20);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
+            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
             this.instanceLabel.TabIndex = 16;
             this.instanceLabel.Text = "Instance";
             // 
@@ -489,14 +463,14 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(114, 26);
-            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.instanceComboBox.Location = new System.Drawing.Point(76, 17);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
+            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
             this.instanceComboBox.TabIndex = 14;
             // 
             // recurrenceGroupBox
             // 
+            this.recurrenceGroupBox.Controls.Add(this.pauseIndefinitelyCheckBox);
             this.recurrenceGroupBox.Controls.Add(this.moreExamplesButton);
             this.recurrenceGroupBox.Controls.Add(this.calculatedRunsTextBox);
             this.recurrenceGroupBox.Controls.Add(this.calculateNextRunsButton);
@@ -513,21 +487,18 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.startAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.minutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.hoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(724, 20);
-            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(483, 13);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 649);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 455);
             this.recurrenceGroupBox.TabIndex = 2;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
             // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(237, 534);
-            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.moreExamplesButton.Location = new System.Drawing.Point(158, 380);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(99, 102);
+            this.moreExamplesButton.Size = new System.Drawing.Size(66, 66);
             this.moreExamplesButton.TabIndex = 27;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -536,22 +507,20 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 534);
-            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(6, 380);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 99);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 66);
             this.calculatedRunsTextBox.TabIndex = 26;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // calculateNextRunsButton
             // 
             this.calculateNextRunsButton.Enabled = false;
-            this.calculateNextRunsButton.Location = new System.Drawing.Point(9, 485);
-            this.calculateNextRunsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.calculateNextRunsButton.Location = new System.Drawing.Point(6, 348);
             this.calculateNextRunsButton.Name = "calculateNextRunsButton";
-            this.calculateNextRunsButton.Size = new System.Drawing.Size(327, 35);
+            this.calculateNextRunsButton.Size = new System.Drawing.Size(218, 23);
             this.calculateNextRunsButton.TabIndex = 25;
             this.calculateNextRunsButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Calculate_next_100_runs_of_cron_trigger;
             this.calculateNextRunsButton.UseVisualStyleBackColor = true;
@@ -560,10 +529,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 454);
-            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 328);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
             this.cronDocsLinkLabel.TabIndex = 30;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -573,19 +541,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.triggerTypePanel.Controls.Add(this.cronTriggerRadioButton);
             this.triggerTypePanel.Controls.Add(this.simpleTriggerRadioButton);
-            this.triggerTypePanel.Location = new System.Drawing.Point(14, 69);
-            this.triggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.triggerTypePanel.Location = new System.Drawing.Point(9, 78);
             this.triggerTypePanel.Name = "triggerTypePanel";
-            this.triggerTypePanel.Size = new System.Drawing.Size(321, 35);
+            this.triggerTypePanel.Size = new System.Drawing.Size(214, 23);
             this.triggerTypePanel.TabIndex = 29;
             // 
             // cronTriggerRadioButton
             // 
             this.cronTriggerRadioButton.AutoSize = true;
-            this.cronTriggerRadioButton.Location = new System.Drawing.Point(194, 8);
-            this.cronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronTriggerRadioButton.Location = new System.Drawing.Point(129, 5);
             this.cronTriggerRadioButton.Name = "cronTriggerRadioButton";
-            this.cronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
+            this.cronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
             this.cronTriggerRadioButton.TabIndex = 23;
             this.cronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.cronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -595,10 +561,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.simpleTriggerRadioButton.AutoSize = true;
             this.simpleTriggerRadioButton.Checked = true;
-            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.simpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
             this.simpleTriggerRadioButton.Name = "simpleTriggerRadioButton";
-            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
+            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
             this.simpleTriggerRadioButton.TabIndex = 22;
             this.simpleTriggerRadioButton.TabStop = true;
             this.simpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -607,10 +572,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(9, 422);
-            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.buildCronLabel.Location = new System.Drawing.Point(6, 307);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
+            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
             this.buildCronLabel.TabIndex = 26;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -618,11 +582,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 178);
-            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 149);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(312, 238);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(208, 155);
             this.cronTriggerInfoTextBox.TabIndex = 25;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -630,10 +593,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(186, 422);
-            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(124, 307);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
             this.cronmakerLinkLabel.TabIndex = 24;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -642,30 +604,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronExpressionLabel
             // 
             this.cronExpressionLabel.AutoSize = true;
-            this.cronExpressionLabel.Location = new System.Drawing.Point(9, 114);
-            this.cronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronExpressionLabel.Location = new System.Drawing.Point(6, 107);
             this.cronExpressionLabel.Name = "cronExpressionLabel";
-            this.cronExpressionLabel.Size = new System.Drawing.Size(123, 20);
+            this.cronExpressionLabel.Size = new System.Drawing.Size(82, 13);
             this.cronExpressionLabel.TabIndex = 23;
             this.cronExpressionLabel.Text = "Cron expression";
             // 
             // cronExpressionTextBox
             // 
             this.cronExpressionTextBox.Enabled = false;
-            this.cronExpressionTextBox.Location = new System.Drawing.Point(14, 138);
-            this.cronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronExpressionTextBox.Location = new System.Drawing.Point(9, 123);
             this.cronExpressionTextBox.Name = "cronExpressionTextBox";
-            this.cronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
+            this.cronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
             this.cronExpressionTextBox.TabIndex = 24;
             this.cronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // minutesLabel
             // 
             this.minutesLabel.AutoSize = true;
-            this.minutesLabel.Location = new System.Drawing.Point(96, 34);
+            this.minutesLabel.Location = new System.Drawing.Point(64, 55);
             this.minutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.minutesLabel.Name = "minutesLabel";
-            this.minutesLabel.Size = new System.Drawing.Size(26, 20);
+            this.minutesLabel.Size = new System.Drawing.Size(19, 13);
             this.minutesLabel.TabIndex = 5;
             this.minutesLabel.Text = "M:";
             this.minutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -673,10 +633,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // hoursLabel
             // 
             this.hoursLabel.AutoSize = true;
-            this.hoursLabel.Location = new System.Drawing.Point(9, 34);
+            this.hoursLabel.Location = new System.Drawing.Point(6, 55);
             this.hoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.hoursLabel.Name = "hoursLabel";
-            this.hoursLabel.Size = new System.Drawing.Size(25, 20);
+            this.hoursLabel.Size = new System.Drawing.Size(18, 13);
             this.hoursLabel.TabIndex = 4;
             this.hoursLabel.Text = "H:";
             this.hoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -684,10 +644,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // startAtLabel
             // 
             this.startAtLabel.AutoSize = true;
-            this.startAtLabel.Location = new System.Drawing.Point(189, 34);
-            this.startAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.startAtLabel.Location = new System.Drawing.Point(126, 55);
             this.startAtLabel.Name = "startAtLabel";
-            this.startAtLabel.Size = new System.Drawing.Size(59, 20);
+            this.startAtLabel.Size = new System.Drawing.Size(39, 13);
             this.startAtLabel.TabIndex = 3;
             this.startAtLabel.Text = "start at";
             this.startAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -696,11 +655,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.startAtDateTimePicker.CustomFormat = "HH:mm";
             this.startAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.startAtDateTimePicker.Location = new System.Drawing.Point(248, 29);
-            this.startAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.startAtDateTimePicker.Location = new System.Drawing.Point(165, 52);
             this.startAtDateTimePicker.Name = "startAtDateTimePicker";
             this.startAtDateTimePicker.ShowUpDown = true;
-            this.startAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
+            this.startAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
             this.startAtDateTimePicker.TabIndex = 21;
             this.startAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -708,11 +666,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.minutesDateTimePicker.CustomFormat = "mm";
             this.minutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.minutesDateTimePicker.Location = new System.Drawing.Point(124, 29);
-            this.minutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.minutesDateTimePicker.Location = new System.Drawing.Point(83, 52);
             this.minutesDateTimePicker.Name = "minutesDateTimePicker";
             this.minutesDateTimePicker.ShowUpDown = true;
-            this.minutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.minutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.minutesDateTimePicker.TabIndex = 20;
             this.minutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -720,11 +677,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.hoursDateTimePicker.CustomFormat = "HH";
             this.hoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.hoursDateTimePicker.Location = new System.Drawing.Point(36, 29);
-            this.hoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.hoursDateTimePicker.Location = new System.Drawing.Point(24, 52);
             this.hoursDateTimePicker.Name = "hoursDateTimePicker";
             this.hoursDateTimePicker.ShowUpDown = true;
-            this.hoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.hoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.hoursDateTimePicker.TabIndex = 19;
             this.hoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -736,10 +692,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.cancelButton,
             this.addJobButton,
             this.customActionsButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 677);
+            this.bottomToolStrip.Location = new System.Drawing.Point(0, 471);
             this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Padding = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.bottomToolStrip.Size = new System.Drawing.Size(1074, 32);
+            this.bottomToolStrip.Size = new System.Drawing.Size(720, 25);
             this.bottomToolStrip.TabIndex = 3;
             // 
             // cancelButton
@@ -748,7 +703,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(67, 29);
+            this.cancelButton.Size = new System.Drawing.Size(47, 22);
             this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
             this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
             // 
@@ -758,7 +713,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(146, 29);
+            this.addJobButton.Size = new System.Drawing.Size(97, 22);
             this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
             this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
             // 
@@ -767,7 +722,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.customActionsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.customActionsButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.customActionsButton.Name = "customActionsButton";
-            this.customActionsButton.Size = new System.Drawing.Size(193, 29);
+            this.customActionsButton.Size = new System.Drawing.Size(129, 22);
             this.customActionsButton.Text = "Custom Odata actions";
             this.customActionsButton.Click += new System.EventHandler(this.CustomActionsButton_Click);
             // 
@@ -777,26 +732,23 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(369, 225);
-            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(246, 146);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 103);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 67);
             this.retryPolicyGroupBox.TabIndex = 7;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(156, 60);
-            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(104, 39);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesDelayUpDown.TabIndex = 7;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -806,15 +758,14 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(156, 23);
-            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(104, 15);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesCountUpDown.TabIndex = 6;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -825,29 +776,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 68);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(7, 44);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(123, 20);
+            this.label2.Size = new System.Drawing.Size(83, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(10, 31);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(7, 20);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(131, 20);
+            this.label1.Size = new System.Drawing.Size(87, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(369, 336);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(246, 218);
+            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 59);
+            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 38);
             this.groupBoxExceptions.TabIndex = 10;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -857,19 +808,31 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(13, 26);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
+            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
+            // pauseIndefinitelyCheckBox
+            // 
+            this.pauseIndefinitelyCheckBox.AutoSize = true;
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(9, 23);
+            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
+            this.pauseIndefinitelyCheckBox.TabIndex = 0;
+            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
+            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            // 
             // ExportJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(1074, 709);
+            this.ClientSize = new System.Drawing.Size(720, 496);
             this.Controls.Add(this.bottomToolStrip);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.retryPolicyGroupBox);
@@ -877,11 +840,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.Controls.Add(this.axDetailsGroupBox);
             this.Controls.Add(this.jobDetailsGroupBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(1096, 765);
+            this.MaximumSize = new System.Drawing.Size(736, 535);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(1096, 765);
+            this.MinimumSize = new System.Drawing.Size(736, 511);
             this.Name = "ExportJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -978,5 +940,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
         private System.Windows.Forms.ToolStripButton customActionsButton;
+        private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
     }
 }

--- a/Scheduler/Forms/ExportJob.Designer.cs
+++ b/Scheduler/Forms/ExportJob.Designer.cs
@@ -66,6 +66,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.instanceLabel = new System.Windows.Forms.Label();
             this.instanceComboBox = new System.Windows.Forms.ComboBox();
             this.recurrenceGroupBox = new System.Windows.Forms.GroupBox();
+            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
             this.moreExamplesButton = new System.Windows.Forms.Button();
             this.calculatedRunsTextBox = new System.Windows.Forms.TextBox();
             this.calculateNextRunsButton = new System.Windows.Forms.Button();
@@ -84,10 +85,6 @@ namespace RecurringIntegrationsScheduler.Forms
             this.startAtDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.minutesDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.hoursDateTimePicker = new System.Windows.Forms.DateTimePicker();
-            this.bottomToolStrip = new System.Windows.Forms.ToolStrip();
-            this.cancelButton = new System.Windows.Forms.ToolStripButton();
-            this.addJobButton = new System.Windows.Forms.ToolStripButton();
-            this.customActionsButton = new System.Windows.Forms.ToolStripButton();
             this.retryPolicyGroupBox = new System.Windows.Forms.GroupBox();
             this.retriesDelayUpDown = new System.Windows.Forms.NumericUpDown();
             this.retriesCountUpDown = new System.Windows.Forms.NumericUpDown();
@@ -95,18 +92,21 @@ namespace RecurringIntegrationsScheduler.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.groupBoxExceptions = new System.Windows.Forms.GroupBox();
             this.pauseOnExceptionsCheckBox = new System.Windows.Forms.CheckBox();
-            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
+            this.groupBoxButtons = new System.Windows.Forms.GroupBox();
+            this.addJobButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.customActionsButton = new System.Windows.Forms.Button();
             this.jobDetailsGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.interval)).BeginInit();
             this.axDetailsGroupBox.SuspendLayout();
             this.authMethodPanel.SuspendLayout();
             this.recurrenceGroupBox.SuspendLayout();
             this.triggerTypePanel.SuspendLayout();
-            this.bottomToolStrip.SuspendLayout();
             this.retryPolicyGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.retriesDelayUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).BeginInit();
             this.groupBoxExceptions.SuspendLayout();
+            this.groupBoxButtons.SuspendLayout();
             this.SuspendLayout();
             // 
             // jobDetailsGroupBox
@@ -133,9 +133,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
+            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(230, 390);
+            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(345, 600);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -144,10 +146,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.addTimestampCheckBox.AutoSize = true;
             this.addTimestampCheckBox.Enabled = false;
-            this.addTimestampCheckBox.Location = new System.Drawing.Point(11, 256);
-            this.addTimestampCheckBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.addTimestampCheckBox.Location = new System.Drawing.Point(16, 394);
+            this.addTimestampCheckBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.addTimestampCheckBox.Name = "addTimestampCheckBox";
-            this.addTimestampCheckBox.Size = new System.Drawing.Size(177, 17);
+            this.addTimestampCheckBox.Size = new System.Drawing.Size(260, 24);
             this.addTimestampCheckBox.TabIndex = 10;
             this.addTimestampCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Make_exported_file_name_unique;
             this.addTimestampCheckBox.UseVisualStyleBackColor = true;
@@ -155,32 +157,34 @@ namespace RecurringIntegrationsScheduler.Forms
             // legalEntityLabel
             // 
             this.legalEntityLabel.AutoSize = true;
-            this.legalEntityLabel.Location = new System.Drawing.Point(10, 325);
+            this.legalEntityLabel.Location = new System.Drawing.Point(15, 500);
+            this.legalEntityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.legalEntityLabel.Name = "legalEntityLabel";
-            this.legalEntityLabel.Size = new System.Drawing.Size(61, 13);
+            this.legalEntityLabel.Size = new System.Drawing.Size(90, 20);
             this.legalEntityLabel.TabIndex = 22;
             this.legalEntityLabel.Text = "Legal entity";
             // 
             // legalEntity
             // 
-            this.legalEntity.Location = new System.Drawing.Point(80, 323);
+            this.legalEntity.Location = new System.Drawing.Point(120, 497);
+            this.legalEntity.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.legalEntity.Name = "legalEntity";
-            this.legalEntity.Size = new System.Drawing.Size(65, 20);
+            this.legalEntity.Size = new System.Drawing.Size(96, 26);
             this.legalEntity.TabIndex = 13;
             // 
             // intervalLabel
             // 
             this.intervalLabel.AutoSize = true;
-            this.intervalLabel.Location = new System.Drawing.Point(10, 350);
+            this.intervalLabel.Location = new System.Drawing.Point(15, 538);
+            this.intervalLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.intervalLabel.Name = "intervalLabel";
-            this.intervalLabel.Size = new System.Drawing.Size(136, 13);
+            this.intervalLabel.Size = new System.Drawing.Size(199, 20);
             this.intervalLabel.TabIndex = 20;
             this.intervalLabel.Text = "Status check interval (sec.)";
             // 
             // interval
             // 
-            this.interval.Location = new System.Drawing.Point(147, 349);
-            this.interval.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.interval.Location = new System.Drawing.Point(220, 537);
             this.interval.Maximum = new decimal(new int[] {
             3600,
             0,
@@ -192,7 +196,7 @@ namespace RecurringIntegrationsScheduler.Forms
             0,
             0});
             this.interval.Name = "interval";
-            this.interval.Size = new System.Drawing.Size(74, 20);
+            this.interval.Size = new System.Drawing.Size(111, 26);
             this.interval.TabIndex = 14;
             this.interval.Value = new decimal(new int[] {
             300,
@@ -203,27 +207,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // dataProjectLabel
             // 
             this.dataProjectLabel.AutoSize = true;
-            this.dataProjectLabel.Location = new System.Drawing.Point(10, 302);
+            this.dataProjectLabel.Location = new System.Drawing.Point(15, 465);
+            this.dataProjectLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.dataProjectLabel.Name = "dataProjectLabel";
-            this.dataProjectLabel.Size = new System.Drawing.Size(65, 13);
+            this.dataProjectLabel.Size = new System.Drawing.Size(96, 20);
             this.dataProjectLabel.TabIndex = 16;
             this.dataProjectLabel.Text = "Data project";
             // 
             // dataProject
             // 
-            this.dataProject.Location = new System.Drawing.Point(79, 300);
+            this.dataProject.Location = new System.Drawing.Point(118, 462);
+            this.dataProject.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.dataProject.Name = "dataProject";
-            this.dataProject.Size = new System.Drawing.Size(148, 20);
+            this.dataProject.Size = new System.Drawing.Size(220, 26);
             this.dataProject.TabIndex = 12;
             // 
             // deletePackageCheckBox
             // 
             this.deletePackageCheckBox.AutoSize = true;
             this.deletePackageCheckBox.Enabled = false;
-            this.deletePackageCheckBox.Location = new System.Drawing.Point(11, 277);
-            this.deletePackageCheckBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.deletePackageCheckBox.Location = new System.Drawing.Point(16, 426);
+            this.deletePackageCheckBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.deletePackageCheckBox.Name = "deletePackageCheckBox";
-            this.deletePackageCheckBox.Size = new System.Drawing.Size(118, 17);
+            this.deletePackageCheckBox.Size = new System.Drawing.Size(171, 24);
             this.deletePackageCheckBox.TabIndex = 11;
             this.deletePackageCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Delete_package_file;
             this.deletePackageCheckBox.UseVisualStyleBackColor = true;
@@ -231,10 +237,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // unzipCheckBox
             // 
             this.unzipCheckBox.AutoSize = true;
-            this.unzipCheckBox.Location = new System.Drawing.Point(12, 235);
-            this.unzipCheckBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.unzipCheckBox.Location = new System.Drawing.Point(18, 362);
+            this.unzipCheckBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.unzipCheckBox.Name = "unzipCheckBox";
-            this.unzipCheckBox.Size = new System.Drawing.Size(114, 17);
+            this.unzipCheckBox.Size = new System.Drawing.Size(165, 24);
             this.unzipCheckBox.TabIndex = 9;
             this.unzipCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Unzip_package_file;
             this.unzipCheckBox.UseVisualStyleBackColor = true;
@@ -245,9 +251,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(12, 172);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(18, 265);
+            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(143, 17);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(213, 24);
             this.useStandardSubfolder.TabIndex = 6;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_folder_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -258,10 +265,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.errorsFolderBrowserButton.Enabled = false;
             this.errorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.errorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(202, 207);
+            this.errorsFolderBrowserButton.Location = new System.Drawing.Point(303, 318);
             this.errorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.errorsFolderBrowserButton.Name = "errorsFolderBrowserButton";
-            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.errorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.errorsFolderBrowserButton.TabIndex = 8;
             this.errorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.errorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -270,17 +277,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // errorsFolder
             // 
             this.errorsFolder.Enabled = false;
-            this.errorsFolder.Location = new System.Drawing.Point(12, 209);
+            this.errorsFolder.Location = new System.Drawing.Point(18, 322);
+            this.errorsFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.errorsFolder.Name = "errorsFolder";
-            this.errorsFolder.Size = new System.Drawing.Size(187, 20);
+            this.errorsFolder.Size = new System.Drawing.Size(278, 26);
             this.errorsFolder.TabIndex = 7;
             // 
             // errorsFolderLabel
             // 
             this.errorsFolderLabel.AutoSize = true;
-            this.errorsFolderLabel.Location = new System.Drawing.Point(9, 192);
+            this.errorsFolderLabel.Location = new System.Drawing.Point(14, 295);
+            this.errorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.errorsFolderLabel.Name = "errorsFolderLabel";
-            this.errorsFolderLabel.Size = new System.Drawing.Size(63, 13);
+            this.errorsFolderLabel.Size = new System.Drawing.Size(96, 20);
             this.errorsFolderLabel.TabIndex = 11;
             this.errorsFolderLabel.Text = "Errors folder";
             // 
@@ -288,10 +297,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.downloadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.downloadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(202, 144);
+            this.downloadFolderBrowserButton.Location = new System.Drawing.Point(303, 222);
             this.downloadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.downloadFolderBrowserButton.Name = "downloadFolderBrowserButton";
-            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.downloadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.downloadFolderBrowserButton.TabIndex = 5;
             this.downloadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.downloadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -299,35 +308,39 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // downloadFolder
             // 
-            this.downloadFolder.Location = new System.Drawing.Point(13, 147);
+            this.downloadFolder.Location = new System.Drawing.Point(20, 226);
+            this.downloadFolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.downloadFolder.Name = "downloadFolder";
-            this.downloadFolder.Size = new System.Drawing.Size(187, 20);
+            this.downloadFolder.Size = new System.Drawing.Size(278, 26);
             this.downloadFolder.TabIndex = 4;
             this.downloadFolder.TextChanged += new System.EventHandler(this.DownloadFolder_TextChanged);
             // 
             // downloadFolderLabel
             // 
             this.downloadFolderLabel.AutoSize = true;
-            this.downloadFolderLabel.Location = new System.Drawing.Point(10, 130);
+            this.downloadFolderLabel.Location = new System.Drawing.Point(15, 200);
+            this.downloadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.downloadFolderLabel.Name = "downloadFolderLabel";
-            this.downloadFolderLabel.Size = new System.Drawing.Size(84, 13);
+            this.downloadFolderLabel.Size = new System.Drawing.Size(124, 20);
             this.downloadFolderLabel.TabIndex = 8;
             this.downloadFolderLabel.Text = "Download folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(11, 91);
+            this.jobDescription.Location = new System.Drawing.Point(16, 140);
+            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(211, 35);
+            this.jobDescription.Size = new System.Drawing.Size(314, 52);
             this.jobDescription.TabIndex = 3;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(9, 74);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(14, 114);
+            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
             this.jobDescriptionLabel.TabIndex = 4;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -335,34 +348,38 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
+            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 2;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(9, 52);
+            this.jobGroupLabel.Location = new System.Drawing.Point(14, 80);
+            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
+            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
             this.jobGroupLabel.TabIndex = 2;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(50, 17);
+            this.jobName.Location = new System.Drawing.Point(75, 26);
+            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(173, 20);
+            this.jobName.Size = new System.Drawing.Size(258, 26);
             this.jobName.TabIndex = 1;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(9, 20);
+            this.jobNameLabel.Location = new System.Drawing.Point(14, 31);
+            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
+            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -375,9 +392,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(247, 13);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(370, 20);
+            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 127);
+            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 195);
             this.axDetailsGroupBox.TabIndex = 1;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -385,9 +404,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(9, 78);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(14, 120);
+            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
             this.aadApplicationLabel.TabIndex = 34;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -395,26 +415,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(103, 75);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(154, 115);
+            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(121, 21);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(180, 28);
             this.aadApplicationComboBox.TabIndex = 17;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(8, 44);
+            this.authMethodPanel.Location = new System.Drawing.Point(12, 68);
+            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(215, 25);
+            this.authMethodPanel.Size = new System.Drawing.Size(322, 38);
             this.authMethodPanel.TabIndex = 31;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
+            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
             this.serviceAuthRadioButton.TabIndex = 16;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -424,9 +447,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
             this.userAuthRadioButton.TabIndex = 15;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -435,9 +459,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(62, 104);
+            this.userLabel.Location = new System.Drawing.Point(93, 160);
+            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(29, 13);
+            this.userLabel.Size = new System.Drawing.Size(43, 20);
             this.userLabel.TabIndex = 19;
             this.userLabel.Text = "User";
             // 
@@ -445,17 +470,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(103, 101);
+            this.userComboBox.Location = new System.Drawing.Point(154, 155);
+            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(121, 21);
+            this.userComboBox.Size = new System.Drawing.Size(180, 28);
             this.userComboBox.TabIndex = 18;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(19, 20);
+            this.instanceLabel.Location = new System.Drawing.Point(28, 31);
+            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
+            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
             this.instanceLabel.TabIndex = 16;
             this.instanceLabel.Text = "Instance";
             // 
@@ -463,9 +490,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(76, 17);
+            this.instanceComboBox.Location = new System.Drawing.Point(114, 26);
+            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
+            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
             this.instanceComboBox.TabIndex = 14;
             // 
             // recurrenceGroupBox
@@ -487,18 +515,31 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.startAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.minutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.hoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(483, 13);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(724, 20);
+            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 455);
+            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 700);
             this.recurrenceGroupBox.TabIndex = 2;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
             // 
+            // pauseIndefinitelyCheckBox
+            // 
+            this.pauseIndefinitelyCheckBox.AutoSize = true;
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(14, 35);
+            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(183, 24);
+            this.pauseIndefinitelyCheckBox.TabIndex = 0;
+            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
+            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(158, 380);
+            this.moreExamplesButton.Location = new System.Drawing.Point(237, 585);
+            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(66, 66);
+            this.moreExamplesButton.Size = new System.Drawing.Size(99, 102);
             this.moreExamplesButton.TabIndex = 27;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -507,20 +548,22 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(6, 380);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 585);
+            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 66);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 99);
             this.calculatedRunsTextBox.TabIndex = 26;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // calculateNextRunsButton
             // 
             this.calculateNextRunsButton.Enabled = false;
-            this.calculateNextRunsButton.Location = new System.Drawing.Point(6, 348);
+            this.calculateNextRunsButton.Location = new System.Drawing.Point(9, 535);
+            this.calculateNextRunsButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.calculateNextRunsButton.Name = "calculateNextRunsButton";
-            this.calculateNextRunsButton.Size = new System.Drawing.Size(218, 23);
+            this.calculateNextRunsButton.Size = new System.Drawing.Size(327, 35);
             this.calculateNextRunsButton.TabIndex = 25;
             this.calculateNextRunsButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Calculate_next_100_runs_of_cron_trigger;
             this.calculateNextRunsButton.UseVisualStyleBackColor = true;
@@ -529,9 +572,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 328);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 505);
+            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
             this.cronDocsLinkLabel.TabIndex = 30;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -541,17 +585,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.triggerTypePanel.Controls.Add(this.cronTriggerRadioButton);
             this.triggerTypePanel.Controls.Add(this.simpleTriggerRadioButton);
-            this.triggerTypePanel.Location = new System.Drawing.Point(9, 78);
+            this.triggerTypePanel.Location = new System.Drawing.Point(14, 120);
+            this.triggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.triggerTypePanel.Name = "triggerTypePanel";
-            this.triggerTypePanel.Size = new System.Drawing.Size(214, 23);
+            this.triggerTypePanel.Size = new System.Drawing.Size(321, 35);
             this.triggerTypePanel.TabIndex = 29;
             // 
             // cronTriggerRadioButton
             // 
             this.cronTriggerRadioButton.AutoSize = true;
-            this.cronTriggerRadioButton.Location = new System.Drawing.Point(129, 5);
+            this.cronTriggerRadioButton.Location = new System.Drawing.Point(194, 8);
+            this.cronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronTriggerRadioButton.Name = "cronTriggerRadioButton";
-            this.cronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
+            this.cronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
             this.cronTriggerRadioButton.TabIndex = 23;
             this.cronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.cronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -561,9 +607,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.simpleTriggerRadioButton.AutoSize = true;
             this.simpleTriggerRadioButton.Checked = true;
-            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.simpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.simpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.simpleTriggerRadioButton.Name = "simpleTriggerRadioButton";
-            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
+            this.simpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
             this.simpleTriggerRadioButton.TabIndex = 22;
             this.simpleTriggerRadioButton.TabStop = true;
             this.simpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -572,9 +619,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(6, 307);
+            this.buildCronLabel.Location = new System.Drawing.Point(9, 472);
+            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
+            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
             this.buildCronLabel.TabIndex = 26;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -582,10 +630,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 149);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 229);
+            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(208, 155);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(312, 238);
             this.cronTriggerInfoTextBox.TabIndex = 25;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -593,9 +642,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(124, 307);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(186, 472);
+            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
             this.cronmakerLinkLabel.TabIndex = 24;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -604,28 +654,30 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronExpressionLabel
             // 
             this.cronExpressionLabel.AutoSize = true;
-            this.cronExpressionLabel.Location = new System.Drawing.Point(6, 107);
+            this.cronExpressionLabel.Location = new System.Drawing.Point(9, 165);
+            this.cronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronExpressionLabel.Name = "cronExpressionLabel";
-            this.cronExpressionLabel.Size = new System.Drawing.Size(82, 13);
+            this.cronExpressionLabel.Size = new System.Drawing.Size(123, 20);
             this.cronExpressionLabel.TabIndex = 23;
             this.cronExpressionLabel.Text = "Cron expression";
             // 
             // cronExpressionTextBox
             // 
             this.cronExpressionTextBox.Enabled = false;
-            this.cronExpressionTextBox.Location = new System.Drawing.Point(9, 123);
+            this.cronExpressionTextBox.Location = new System.Drawing.Point(14, 189);
+            this.cronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronExpressionTextBox.Name = "cronExpressionTextBox";
-            this.cronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
+            this.cronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
             this.cronExpressionTextBox.TabIndex = 24;
             this.cronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // minutesLabel
             // 
             this.minutesLabel.AutoSize = true;
-            this.minutesLabel.Location = new System.Drawing.Point(64, 55);
+            this.minutesLabel.Location = new System.Drawing.Point(96, 85);
             this.minutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.minutesLabel.Name = "minutesLabel";
-            this.minutesLabel.Size = new System.Drawing.Size(19, 13);
+            this.minutesLabel.Size = new System.Drawing.Size(26, 20);
             this.minutesLabel.TabIndex = 5;
             this.minutesLabel.Text = "M:";
             this.minutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -633,10 +685,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // hoursLabel
             // 
             this.hoursLabel.AutoSize = true;
-            this.hoursLabel.Location = new System.Drawing.Point(6, 55);
+            this.hoursLabel.Location = new System.Drawing.Point(9, 85);
             this.hoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.hoursLabel.Name = "hoursLabel";
-            this.hoursLabel.Size = new System.Drawing.Size(18, 13);
+            this.hoursLabel.Size = new System.Drawing.Size(25, 20);
             this.hoursLabel.TabIndex = 4;
             this.hoursLabel.Text = "H:";
             this.hoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -644,9 +696,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // startAtLabel
             // 
             this.startAtLabel.AutoSize = true;
-            this.startAtLabel.Location = new System.Drawing.Point(126, 55);
+            this.startAtLabel.Location = new System.Drawing.Point(189, 85);
+            this.startAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.startAtLabel.Name = "startAtLabel";
-            this.startAtLabel.Size = new System.Drawing.Size(39, 13);
+            this.startAtLabel.Size = new System.Drawing.Size(59, 20);
             this.startAtLabel.TabIndex = 3;
             this.startAtLabel.Text = "start at";
             this.startAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -655,10 +708,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.startAtDateTimePicker.CustomFormat = "HH:mm";
             this.startAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.startAtDateTimePicker.Location = new System.Drawing.Point(165, 52);
+            this.startAtDateTimePicker.Location = new System.Drawing.Point(248, 80);
+            this.startAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.startAtDateTimePicker.Name = "startAtDateTimePicker";
             this.startAtDateTimePicker.ShowUpDown = true;
-            this.startAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
+            this.startAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
             this.startAtDateTimePicker.TabIndex = 21;
             this.startAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -666,10 +720,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.minutesDateTimePicker.CustomFormat = "mm";
             this.minutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.minutesDateTimePicker.Location = new System.Drawing.Point(83, 52);
+            this.minutesDateTimePicker.Location = new System.Drawing.Point(124, 80);
+            this.minutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.minutesDateTimePicker.Name = "minutesDateTimePicker";
             this.minutesDateTimePicker.ShowUpDown = true;
-            this.minutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.minutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.minutesDateTimePicker.TabIndex = 20;
             this.minutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -677,54 +732,13 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.hoursDateTimePicker.CustomFormat = "HH";
             this.hoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.hoursDateTimePicker.Location = new System.Drawing.Point(24, 52);
+            this.hoursDateTimePicker.Location = new System.Drawing.Point(36, 80);
+            this.hoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.hoursDateTimePicker.Name = "hoursDateTimePicker";
             this.hoursDateTimePicker.ShowUpDown = true;
-            this.hoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.hoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.hoursDateTimePicker.TabIndex = 19;
             this.hoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
-            // 
-            // bottomToolStrip
-            // 
-            this.bottomToolStrip.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.bottomToolStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.bottomToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cancelButton,
-            this.addJobButton,
-            this.customActionsButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 471);
-            this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Size = new System.Drawing.Size(720, 25);
-            this.bottomToolStrip.TabIndex = 3;
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(47, 22);
-            this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
-            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
-            // 
-            // addJobButton
-            // 
-            this.addJobButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(97, 22);
-            this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
-            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
-            // 
-            // customActionsButton
-            // 
-            this.customActionsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.customActionsButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.customActionsButton.Name = "customActionsButton";
-            this.customActionsButton.Size = new System.Drawing.Size(129, 22);
-            this.customActionsButton.Text = "Custom Odata actions";
-            this.customActionsButton.Click += new System.EventHandler(this.CustomActionsButton_Click);
             // 
             // retryPolicyGroupBox
             // 
@@ -732,23 +746,26 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(246, 146);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(369, 225);
+            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 67);
+            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 103);
             this.retryPolicyGroupBox.TabIndex = 7;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(104, 39);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(156, 60);
+            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesDelayUpDown.TabIndex = 7;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -758,14 +775,15 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(104, 15);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(156, 23);
+            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesCountUpDown.TabIndex = 6;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -776,29 +794,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(7, 44);
+            this.label2.Location = new System.Drawing.Point(10, 68);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 13);
+            this.label2.Size = new System.Drawing.Size(123, 20);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(7, 20);
+            this.label1.Location = new System.Drawing.Point(10, 31);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(87, 13);
+            this.label1.Size = new System.Drawing.Size(131, 20);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(246, 218);
-            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(369, 335);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 38);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 58);
             this.groupBoxExceptions.TabIndex = 10;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -808,42 +826,71 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
-            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(14, 26);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
-            // pauseIndefinitelyCheckBox
+            // groupBoxButtons
             // 
-            this.pauseIndefinitelyCheckBox.AutoSize = true;
-            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(9, 23);
-            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
-            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
-            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
-            this.pauseIndefinitelyCheckBox.TabIndex = 0;
-            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
-            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            this.groupBoxButtons.Controls.Add(this.addJobButton);
+            this.groupBoxButtons.Controls.Add(this.cancelButton);
+            this.groupBoxButtons.Controls.Add(this.customActionsButton);
+            this.groupBoxButtons.Location = new System.Drawing.Point(14, 728);
+            this.groupBoxButtons.Name = "groupBoxButtons";
+            this.groupBoxButtons.Size = new System.Drawing.Size(1055, 71);
+            this.groupBoxButtons.TabIndex = 11;
+            this.groupBoxButtons.TabStop = false;
+            // 
+            // addJobButton
+            // 
+            this.addJobButton.Location = new System.Drawing.Point(709, 25);
+            this.addJobButton.Name = "addJobButton";
+            this.addJobButton.Size = new System.Drawing.Size(162, 34);
+            this.addJobButton.TabIndex = 2;
+            this.addJobButton.Text = "Add to schedule";
+            this.addJobButton.UseVisualStyleBackColor = true;
+            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.Location = new System.Drawing.Point(887, 25);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(162, 34);
+            this.cancelButton.TabIndex = 1;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
+            // 
+            // customActionsButton
+            // 
+            this.customActionsButton.Location = new System.Drawing.Point(6, 25);
+            this.customActionsButton.Name = "customActionsButton";
+            this.customActionsButton.Size = new System.Drawing.Size(288, 34);
+            this.customActionsButton.TabIndex = 0;
+            this.customActionsButton.Text = "Custom Odata actions";
+            this.customActionsButton.UseVisualStyleBackColor = true;
+            this.customActionsButton.Click += new System.EventHandler(this.CustomActionsButton_Click);
             // 
             // ExportJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(720, 496);
-            this.Controls.Add(this.bottomToolStrip);
+            this.ClientSize = new System.Drawing.Size(1071, 811);
+            this.Controls.Add(this.groupBoxButtons);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.retryPolicyGroupBox);
             this.Controls.Add(this.recurrenceGroupBox);
             this.Controls.Add(this.axDetailsGroupBox);
             this.Controls.Add(this.jobDetailsGroupBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(736, 535);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(736, 511);
+            this.MinimumSize = new System.Drawing.Size(1093, 756);
             this.Name = "ExportJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -861,16 +908,14 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.PerformLayout();
             this.triggerTypePanel.ResumeLayout(false);
             this.triggerTypePanel.PerformLayout();
-            this.bottomToolStrip.ResumeLayout(false);
-            this.bottomToolStrip.PerformLayout();
             this.retryPolicyGroupBox.ResumeLayout(false);
             this.retryPolicyGroupBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.retriesDelayUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).EndInit();
             this.groupBoxExceptions.ResumeLayout(false);
             this.groupBoxExceptions.PerformLayout();
+            this.groupBoxButtons.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -911,13 +956,10 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.Panel triggerTypePanel;
         private System.Windows.Forms.RadioButton cronTriggerRadioButton;
         private System.Windows.Forms.RadioButton simpleTriggerRadioButton;
-        private System.Windows.Forms.ToolStrip bottomToolStrip;
         private System.Windows.Forms.LinkLabel cronDocsLinkLabel;
         private System.Windows.Forms.TextBox calculatedRunsTextBox;
         private System.Windows.Forms.Button calculateNextRunsButton;
         private System.Windows.Forms.Button moreExamplesButton;
-        private System.Windows.Forms.ToolStripButton cancelButton;
-        private System.Windows.Forms.ToolStripButton addJobButton;
         private System.Windows.Forms.CheckBox unzipCheckBox;
         private System.Windows.Forms.CheckBox deletePackageCheckBox;
         private System.Windows.Forms.Panel authMethodPanel;
@@ -939,7 +981,10 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.NumericUpDown retriesCountUpDown;
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
-        private System.Windows.Forms.ToolStripButton customActionsButton;
         private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
+        private System.Windows.Forms.GroupBox groupBoxButtons;
+        private System.Windows.Forms.Button addJobButton;
+        private System.Windows.Forms.Button cancelButton;
+        private System.Windows.Forms.Button customActionsButton;
     }
 }

--- a/Scheduler/Forms/ExportJob.cs
+++ b/Scheduler/Forms/ExportJob.cs
@@ -194,6 +194,10 @@ namespace RecurringIntegrationsScheduler.Forms
                 }
                 instanceComboBox.SelectedItem = axInstance;
 
+                pauseIndefinitelyCheckBox.Checked =
+                    (JobDetail.JobDataMap[SettingsConstants.IndefinitePause] != null) &&
+                    Convert.ToBoolean(JobDetail.JobDataMap[SettingsConstants.IndefinitePause].ToString());
+
                 if (Trigger.GetType() == typeof(SimpleTriggerImpl))
                 {
                     var localTrigger = (SimpleTriggerImpl) Trigger;
@@ -401,7 +405,8 @@ namespace RecurringIntegrationsScheduler.Forms
                 {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()},
                 {SettingsConstants.ExportToPackageActionPath, exportToPackagePath},
                 {SettingsConstants.GetExecutionSummaryStatusActionPath, getExecutionSummaryStatusPath},
-                {SettingsConstants.GetExportedPackageUrlActionPath, getExportedPackageUrlPath}
+                {SettingsConstants.GetExportedPackageUrlActionPath, getExportedPackageUrlPath},
+                {SettingsConstants.IndefinitePause, pauseIndefinitelyCheckBox.Checked.ToString()}
             };
             if (serviceAuthRadioButton.Checked)
             {

--- a/Scheduler/Forms/ExportJob.resx
+++ b/Scheduler/Forms/ExportJob.resx
@@ -125,7 +125,4 @@
 
 Default example above means: Each working day of the week (MON-FRI) run every 15 minutes (0/15) between 8:00 and 18:45 (8-18 - last run will be at 18:45)</value>
   </data>
-  <metadata name="bottomToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>245, 17</value>
-  </metadata>
 </root>

--- a/Scheduler/Forms/ImportJob.Designer.cs
+++ b/Scheduler/Forms/ImportJob.Designer.cs
@@ -76,6 +76,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.instanceLabel = new System.Windows.Forms.Label();
             this.instanceComboBox = new System.Windows.Forms.ComboBox();
             this.recurrenceGroupBox = new System.Windows.Forms.GroupBox();
+            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
             this.getCronScheduleForProcButton = new System.Windows.Forms.Button();
             this.moreExamplesButton = new System.Windows.Forms.Button();
             this.calculatedRunsTextBox = new System.Windows.Forms.TextBox();
@@ -95,10 +96,6 @@ namespace RecurringIntegrationsScheduler.Forms
             this.upJobStartAtDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.upJobMinutesDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.upJobHoursDateTimePicker = new System.Windows.Forms.DateTimePicker();
-            this.bottomToolStrip = new System.Windows.Forms.ToolStrip();
-            this.cancelButton = new System.Windows.Forms.ToolStripButton();
-            this.addJobButton = new System.Windows.Forms.ToolStripButton();
-            this.customActionsButton = new System.Windows.Forms.ToolStripButton();
             this.downloadFolderLabel = new System.Windows.Forms.Label();
             this.processingJobGroupBox = new System.Windows.Forms.GroupBox();
             this.procJobTriggerTypePanel = new System.Windows.Forms.Panel();
@@ -135,13 +132,15 @@ namespace RecurringIntegrationsScheduler.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.groupBoxExceptions = new System.Windows.Forms.GroupBox();
             this.pauseOnExceptionsCheckBox = new System.Windows.Forms.CheckBox();
-            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
+            this.groupBoxButtons = new System.Windows.Forms.GroupBox();
+            this.addJobButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.customActionsButton = new System.Windows.Forms.Button();
             this.jobDetailsGroupBox.SuspendLayout();
             this.axDetailsGroupBox.SuspendLayout();
             this.authMethodPanel.SuspendLayout();
             this.recurrenceGroupBox.SuspendLayout();
             this.upJobTriggerTypePanel.SuspendLayout();
-            this.bottomToolStrip.SuspendLayout();
             this.processingJobGroupBox.SuspendLayout();
             this.procJobTriggerTypePanel.SuspendLayout();
             this.fileSelectionGroupBox.SuspendLayout();
@@ -151,6 +150,7 @@ namespace RecurringIntegrationsScheduler.Forms
             ((System.ComponentModel.ISupportInitialize)(this.retriesDelayUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).BeginInit();
             this.groupBoxExceptions.SuspendLayout();
+            this.groupBoxButtons.SuspendLayout();
             this.SuspendLayout();
             // 
             // jobDetailsGroupBox
@@ -187,9 +187,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
+            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(229, 480);
+            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(344, 738);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -198,10 +200,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.PackageTemplateFileBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.PackageTemplateFileBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.PackageTemplateFileBrowserButton.Location = new System.Drawing.Point(200, 404);
+            this.PackageTemplateFileBrowserButton.Location = new System.Drawing.Point(300, 622);
             this.PackageTemplateFileBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.PackageTemplateFileBrowserButton.Name = "PackageTemplateFileBrowserButton";
-            this.PackageTemplateFileBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.PackageTemplateFileBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.PackageTemplateFileBrowserButton.TabIndex = 29;
             this.PackageTemplateFileBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.PackageTemplateFileBrowserButton.UseVisualStyleBackColor = true;
@@ -209,17 +211,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // packageTemplateTextBox
             // 
-            this.packageTemplateTextBox.Location = new System.Drawing.Point(11, 408);
+            this.packageTemplateTextBox.Location = new System.Drawing.Point(16, 628);
+            this.packageTemplateTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.packageTemplateTextBox.Name = "packageTemplateTextBox";
-            this.packageTemplateTextBox.Size = new System.Drawing.Size(187, 20);
+            this.packageTemplateTextBox.Size = new System.Drawing.Size(278, 26);
             this.packageTemplateTextBox.TabIndex = 28;
             // 
             // PackageTemplateLabel
             // 
             this.PackageTemplateLabel.AutoSize = true;
-            this.PackageTemplateLabel.Location = new System.Drawing.Point(8, 391);
+            this.PackageTemplateLabel.Location = new System.Drawing.Point(12, 602);
+            this.PackageTemplateLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.PackageTemplateLabel.Name = "PackageTemplateLabel";
-            this.PackageTemplateLabel.Size = new System.Drawing.Size(93, 13);
+            this.PackageTemplateLabel.Size = new System.Drawing.Size(137, 20);
             this.PackageTemplateLabel.TabIndex = 10;
             this.PackageTemplateLabel.Text = "Package template";
             // 
@@ -228,10 +232,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingErrorsFolderBrowserButton.Enabled = false;
             this.processingErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 368);
+            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 566);
             this.processingErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingErrorsFolderBrowserButton.Name = "processingErrorsFolderBrowserButton";
-            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.processingErrorsFolderBrowserButton.TabIndex = 27;
             this.processingErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -240,26 +244,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingErrorsFolderTextBox
             // 
             this.processingErrorsFolderTextBox.Enabled = false;
-            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(11, 372);
+            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(16, 572);
+            this.processingErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.processingErrorsFolderTextBox.Name = "processingErrorsFolderTextBox";
-            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.processingErrorsFolderTextBox.TabIndex = 26;
             // 
             // processingErrorsFolderLabel
             // 
             this.processingErrorsFolderLabel.AutoSize = true;
-            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(8, 354);
+            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(12, 545);
+            this.processingErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.processingErrorsFolderLabel.Name = "processingErrorsFolderLabel";
-            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(117, 13);
+            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(176, 20);
             this.processingErrorsFolderLabel.TabIndex = 9;
             this.processingErrorsFolderLabel.Text = "Processing errors folder";
             // 
             // statusFileExtensionTextBox
             // 
             this.statusFileExtensionTextBox.Enabled = false;
-            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(145, 456);
+            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(218, 702);
+            this.statusFileExtensionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.statusFileExtensionTextBox.Name = "statusFileExtensionTextBox";
-            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(81, 20);
+            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(120, 26);
             this.statusFileExtensionTextBox.TabIndex = 31;
             this.statusFileExtensionTextBox.Text = ".Status";
             this.statusFileExtensionTextBox.Leave += new System.EventHandler(this.StatusFileExtensionTextBox_Leave);
@@ -267,25 +274,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // statusFileExtensionLabel
             // 
             this.statusFileExtensionLabel.AutoSize = true;
-            this.statusFileExtensionLabel.Location = new System.Drawing.Point(38, 460);
+            this.statusFileExtensionLabel.Location = new System.Drawing.Point(57, 708);
+            this.statusFileExtensionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.statusFileExtensionLabel.Name = "statusFileExtensionLabel";
-            this.statusFileExtensionLabel.Size = new System.Drawing.Size(101, 13);
+            this.statusFileExtensionLabel.Size = new System.Drawing.Size(152, 20);
             this.statusFileExtensionLabel.TabIndex = 12;
             this.statusFileExtensionLabel.Text = "Status file extension";
             // 
             // legalEntityTextBox
             // 
-            this.legalEntityTextBox.Location = new System.Drawing.Point(145, 433);
+            this.legalEntityTextBox.Location = new System.Drawing.Point(218, 666);
+            this.legalEntityTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.legalEntityTextBox.Name = "legalEntityTextBox";
-            this.legalEntityTextBox.Size = new System.Drawing.Size(81, 20);
+            this.legalEntityTextBox.Size = new System.Drawing.Size(120, 26);
             this.legalEntityTextBox.TabIndex = 30;
             // 
             // LegalEntityLabel
             // 
             this.LegalEntityLabel.AutoSize = true;
-            this.LegalEntityLabel.Location = new System.Drawing.Point(79, 435);
+            this.LegalEntityLabel.Location = new System.Drawing.Point(118, 669);
+            this.LegalEntityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LegalEntityLabel.Name = "LegalEntityLabel";
-            this.LegalEntityLabel.Size = new System.Drawing.Size(61, 13);
+            this.LegalEntityLabel.Size = new System.Drawing.Size(90, 20);
             this.LegalEntityLabel.TabIndex = 11;
             this.LegalEntityLabel.Text = "Legal entity";
             // 
@@ -294,10 +304,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.inputFolderBrowserButton.Enabled = false;
             this.inputFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.inputFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.inputFolderBrowserButton.Location = new System.Drawing.Point(200, 209);
+            this.inputFolderBrowserButton.Location = new System.Drawing.Point(300, 322);
             this.inputFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.inputFolderBrowserButton.Name = "inputFolderBrowserButton";
-            this.inputFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.inputFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.inputFolderBrowserButton.TabIndex = 19;
             this.inputFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.inputFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -306,17 +316,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // inputFolderTextBox
             // 
             this.inputFolderTextBox.Enabled = false;
-            this.inputFolderTextBox.Location = new System.Drawing.Point(11, 213);
+            this.inputFolderTextBox.Location = new System.Drawing.Point(16, 328);
+            this.inputFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.inputFolderTextBox.Name = "inputFolderTextBox";
-            this.inputFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.inputFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.inputFolderTextBox.TabIndex = 18;
             // 
             // inputFolderLabel
             // 
             this.inputFolderLabel.AutoSize = true;
-            this.inputFolderLabel.Location = new System.Drawing.Point(8, 195);
+            this.inputFolderLabel.Location = new System.Drawing.Point(12, 300);
+            this.inputFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.inputFolderLabel.Name = "inputFolderLabel";
-            this.inputFolderLabel.Size = new System.Drawing.Size(77, 13);
+            this.inputFolderLabel.Size = new System.Drawing.Size(116, 20);
             this.inputFolderLabel.TabIndex = 5;
             this.inputFolderLabel.Text = "Input subfolder";
             // 
@@ -325,10 +337,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingSuccessFolderBrowserButton.Enabled = false;
             this.processingSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 328);
+            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 505);
             this.processingSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingSuccessFolderBrowserButton.Name = "processingSuccessFolderBrowserButton";
-            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.processingSuccessFolderBrowserButton.TabIndex = 25;
             this.processingSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -337,17 +349,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingSuccessFolderTextBox
             // 
             this.processingSuccessFolderTextBox.Enabled = false;
-            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(11, 332);
+            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(16, 511);
+            this.processingSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.processingSuccessFolderTextBox.Name = "processingSuccessFolderTextBox";
-            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.processingSuccessFolderTextBox.TabIndex = 24;
             // 
             // processingSuccessFolderLabel
             // 
             this.processingSuccessFolderLabel.AutoSize = true;
-            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(8, 315);
+            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(12, 485);
+            this.processingSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.processingSuccessFolderLabel.Name = "processingSuccessFolderLabel";
-            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(130, 13);
+            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(193, 20);
             this.processingSuccessFolderLabel.TabIndex = 8;
             this.processingSuccessFolderLabel.Text = "Processing success folder";
             // 
@@ -356,10 +370,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadSuccessFolderBrowserButton.Enabled = false;
             this.uploadSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 248);
+            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 382);
             this.uploadSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadSuccessFolderBrowserButton.Name = "uploadSuccessFolderBrowserButton";
-            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.uploadSuccessFolderBrowserButton.TabIndex = 21;
             this.uploadSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -368,17 +382,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadSuccessFolderTextBox
             // 
             this.uploadSuccessFolderTextBox.Enabled = false;
-            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(11, 253);
+            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(16, 389);
+            this.uploadSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.uploadSuccessFolderTextBox.Name = "uploadSuccessFolderTextBox";
-            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.uploadSuccessFolderTextBox.TabIndex = 20;
             // 
             // uploadSuccessFolderLabel
             // 
             this.uploadSuccessFolderLabel.AutoSize = true;
-            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(8, 235);
+            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(12, 362);
+            this.uploadSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uploadSuccessFolderLabel.Name = "uploadSuccessFolderLabel";
-            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(112, 13);
+            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(166, 20);
             this.uploadSuccessFolderLabel.TabIndex = 6;
             this.uploadSuccessFolderLabel.Text = "Upload success folder";
             // 
@@ -387,9 +403,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(11, 174);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(16, 268);
+            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(165, 17);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(247, 24);
             this.useStandardSubfolder.TabIndex = 4;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_subfolders_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -400,10 +417,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadErrorsFolderBrowserButton.Enabled = false;
             this.uploadErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 289);
+            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 445);
             this.uploadErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadErrorsFolderBrowserButton.Name = "uploadErrorsFolderBrowserButton";
-            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.uploadErrorsFolderBrowserButton.TabIndex = 23;
             this.uploadErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -412,17 +429,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadErrorsFolderTextBox
             // 
             this.uploadErrorsFolderTextBox.Enabled = false;
-            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(11, 292);
+            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(16, 449);
+            this.uploadErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.uploadErrorsFolderTextBox.Name = "uploadErrorsFolderTextBox";
-            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.uploadErrorsFolderTextBox.TabIndex = 22;
             // 
             // uploadErrorsFolderLabel
             // 
             this.uploadErrorsFolderLabel.AutoSize = true;
-            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(8, 274);
+            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(12, 422);
+            this.uploadErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uploadErrorsFolderLabel.Name = "uploadErrorsFolderLabel";
-            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(99, 13);
+            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(149, 20);
             this.uploadErrorsFolderLabel.TabIndex = 7;
             this.uploadErrorsFolderLabel.Text = "Upload errors folder";
             // 
@@ -430,10 +449,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.topUploadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.topUploadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(200, 148);
+            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(300, 228);
             this.topUploadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.topUploadFolderBrowserButton.Name = "topUploadFolderBrowserButton";
-            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.topUploadFolderBrowserButton.TabIndex = 17;
             this.topUploadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.topUploadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -441,35 +460,39 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // topUploadFolderTextBox
             // 
-            this.topUploadFolderTextBox.Location = new System.Drawing.Point(11, 152);
+            this.topUploadFolderTextBox.Location = new System.Drawing.Point(16, 234);
+            this.topUploadFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.topUploadFolderTextBox.Name = "topUploadFolderTextBox";
-            this.topUploadFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.topUploadFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.topUploadFolderTextBox.TabIndex = 16;
             this.topUploadFolderTextBox.TextChanged += new System.EventHandler(this.TopUploadFolder_TextChanged);
             // 
             // topUploadFolderLabel
             // 
             this.topUploadFolderLabel.AutoSize = true;
-            this.topUploadFolderLabel.Location = new System.Drawing.Point(8, 134);
+            this.topUploadFolderLabel.Location = new System.Drawing.Point(12, 206);
+            this.topUploadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.topUploadFolderLabel.Name = "topUploadFolderLabel";
-            this.topUploadFolderLabel.Size = new System.Drawing.Size(90, 13);
+            this.topUploadFolderLabel.Size = new System.Drawing.Size(132, 20);
             this.topUploadFolderLabel.TabIndex = 3;
             this.topUploadFolderLabel.Text = "Top upload folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(12, 94);
+            this.jobDescription.Location = new System.Drawing.Point(18, 145);
+            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(211, 36);
+            this.jobDescription.Size = new System.Drawing.Size(314, 53);
             this.jobDescription.TabIndex = 15;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(8, 77);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(12, 118);
+            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
             this.jobDescriptionLabel.TabIndex = 2;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -477,34 +500,38 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
+            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 14;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(8, 52);
+            this.jobGroupLabel.Location = new System.Drawing.Point(12, 80);
+            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
+            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
             this.jobGroupLabel.TabIndex = 1;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(50, 17);
+            this.jobName.Location = new System.Drawing.Point(75, 26);
+            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(173, 20);
+            this.jobName.Size = new System.Drawing.Size(258, 26);
             this.jobName.TabIndex = 13;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(8, 20);
+            this.jobNameLabel.Location = new System.Drawing.Point(12, 31);
+            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
+            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -517,9 +544,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(250, 211);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(375, 325);
+            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 131);
+            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 202);
             this.axDetailsGroupBox.TabIndex = 3;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -527,9 +556,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(12, 79);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(18, 122);
+            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
             this.aadApplicationLabel.TabIndex = 1;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -537,26 +567,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(103, 77);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(154, 118);
+            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(121, 21);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(180, 28);
             this.aadApplicationComboBox.TabIndex = 4;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(7, 45);
+            this.authMethodPanel.Location = new System.Drawing.Point(10, 69);
+            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(215, 25);
+            this.authMethodPanel.Size = new System.Drawing.Size(322, 38);
             this.authMethodPanel.TabIndex = 30;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
+            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
             this.serviceAuthRadioButton.TabIndex = 1;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -566,9 +599,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
             this.userAuthRadioButton.TabIndex = 0;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -577,9 +611,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(65, 105);
+            this.userLabel.Location = new System.Drawing.Point(98, 162);
+            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(29, 13);
+            this.userLabel.Size = new System.Drawing.Size(43, 20);
             this.userLabel.TabIndex = 2;
             this.userLabel.Text = "User";
             // 
@@ -587,17 +622,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(103, 103);
+            this.userComboBox.Location = new System.Drawing.Point(154, 158);
+            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(121, 21);
+            this.userComboBox.Size = new System.Drawing.Size(180, 28);
             this.userComboBox.TabIndex = 5;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(19, 22);
+            this.instanceLabel.Location = new System.Drawing.Point(28, 34);
+            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
+            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
             this.instanceLabel.TabIndex = 0;
             this.instanceLabel.Text = "Instance";
             // 
@@ -605,9 +642,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(76, 19);
+            this.instanceComboBox.Location = new System.Drawing.Point(114, 29);
+            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
+            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
             this.instanceComboBox.TabIndex = 3;
             // 
             // recurrenceGroupBox
@@ -630,19 +668,32 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.upJobStartAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobMinutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobHoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(486, 13);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(729, 20);
+            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 448);
+            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 689);
             this.recurrenceGroupBox.TabIndex = 6;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
             // 
+            // pauseIndefinitelyCheckBox
+            // 
+            this.pauseIndefinitelyCheckBox.AutoSize = true;
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(15, 29);
+            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(183, 24);
+            this.pauseIndefinitelyCheckBox.TabIndex = 0;
+            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
+            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            // 
             // getCronScheduleForProcButton
             // 
             this.getCronScheduleForProcButton.Enabled = false;
-            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(119, 336);
+            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(178, 517);
+            this.getCronScheduleForProcButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.getCronScheduleForProcButton.Name = "getCronScheduleForProcButton";
-            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(105, 36);
+            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(158, 55);
             this.getCronScheduleForProcButton.TabIndex = 13;
             this.getCronScheduleForProcButton.Text = "Get cron schedule for monitoring job ";
             this.getCronScheduleForProcButton.UseVisualStyleBackColor = true;
@@ -650,9 +701,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(158, 376);
+            this.moreExamplesButton.Location = new System.Drawing.Point(237, 578);
+            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(66, 55);
+            this.moreExamplesButton.Size = new System.Drawing.Size(99, 85);
             this.moreExamplesButton.TabIndex = 15;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -661,20 +713,22 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 376);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(14, 578);
+            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 55);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 82);
             this.calculatedRunsTextBox.TabIndex = 14;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // getCronScheduleForUploadButton
             // 
             this.getCronScheduleForUploadButton.Enabled = false;
-            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(9, 336);
+            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(14, 517);
+            this.getCronScheduleForUploadButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.getCronScheduleForUploadButton.Name = "getCronScheduleForUploadButton";
-            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(105, 36);
+            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(158, 55);
             this.getCronScheduleForUploadButton.TabIndex = 12;
             this.getCronScheduleForUploadButton.Text = "Get cron schedule for import job ";
             this.getCronScheduleForUploadButton.UseVisualStyleBackColor = true;
@@ -683,9 +737,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 316);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 486);
+            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
             this.cronDocsLinkLabel.TabIndex = 11;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -695,17 +750,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobTriggerTypePanel.Controls.Add(this.upJobCronTriggerRadioButton);
             this.upJobTriggerTypePanel.Controls.Add(this.upJobSimpleTriggerRadioButton);
-            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(9, 74);
+            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(14, 114);
+            this.upJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobTriggerTypePanel.Name = "upJobTriggerTypePanel";
-            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
+            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
             this.upJobTriggerTypePanel.TabIndex = 29;
             // 
             // upJobCronTriggerRadioButton
             // 
             this.upJobCronTriggerRadioButton.AutoSize = true;
-            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 3);
+            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 5);
+            this.upJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobCronTriggerRadioButton.Name = "upJobCronTriggerRadioButton";
-            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
+            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
             this.upJobCronTriggerRadioButton.TabIndex = 1;
             this.upJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.upJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -715,9 +772,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobSimpleTriggerRadioButton.AutoSize = true;
             this.upJobSimpleTriggerRadioButton.Checked = true;
-            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.upJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobSimpleTriggerRadioButton.Name = "upJobSimpleTriggerRadioButton";
-            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
+            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
             this.upJobSimpleTriggerRadioButton.TabIndex = 0;
             this.upJobSimpleTriggerRadioButton.TabStop = true;
             this.upJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -726,9 +784,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(6, 297);
+            this.buildCronLabel.Location = new System.Drawing.Point(9, 457);
+            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
+            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
             this.buildCronLabel.TabIndex = 5;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -736,10 +795,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 147);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 226);
+            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(215, 147);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(322, 226);
             this.cronTriggerInfoTextBox.TabIndex = 4;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -747,9 +807,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(126, 297);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(189, 457);
+            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
             this.cronmakerLinkLabel.TabIndex = 10;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -758,28 +819,30 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobCronExpressionLabel
             // 
             this.upJobCronExpressionLabel.AutoSize = true;
-            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(6, 106);
+            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(9, 163);
+            this.upJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.upJobCronExpressionLabel.Name = "upJobCronExpressionLabel";
-            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
+            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
             this.upJobCronExpressionLabel.TabIndex = 3;
             this.upJobCronExpressionLabel.Text = "Cron expression";
             // 
             // upJobCronExpressionTextBox
             // 
             this.upJobCronExpressionTextBox.Enabled = false;
-            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 121);
+            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 186);
+            this.upJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobCronExpressionTextBox.Name = "upJobCronExpressionTextBox";
-            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
+            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
             this.upJobCronExpressionTextBox.TabIndex = 9;
             this.upJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // upJobMinutesLabel
             // 
             this.upJobMinutesLabel.AutoSize = true;
-            this.upJobMinutesLabel.Location = new System.Drawing.Point(64, 51);
+            this.upJobMinutesLabel.Location = new System.Drawing.Point(96, 78);
             this.upJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobMinutesLabel.Name = "upJobMinutesLabel";
-            this.upJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
+            this.upJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
             this.upJobMinutesLabel.TabIndex = 1;
             this.upJobMinutesLabel.Text = "M:";
             this.upJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -787,10 +850,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobHoursLabel
             // 
             this.upJobHoursLabel.AutoSize = true;
-            this.upJobHoursLabel.Location = new System.Drawing.Point(6, 51);
+            this.upJobHoursLabel.Location = new System.Drawing.Point(9, 78);
             this.upJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobHoursLabel.Name = "upJobHoursLabel";
-            this.upJobHoursLabel.Size = new System.Drawing.Size(18, 13);
+            this.upJobHoursLabel.Size = new System.Drawing.Size(25, 20);
             this.upJobHoursLabel.TabIndex = 0;
             this.upJobHoursLabel.Text = "H:";
             this.upJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -798,9 +861,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobStartAtLabel
             // 
             this.upJobStartAtLabel.AutoSize = true;
-            this.upJobStartAtLabel.Location = new System.Drawing.Point(126, 51);
+            this.upJobStartAtLabel.Location = new System.Drawing.Point(189, 78);
+            this.upJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.upJobStartAtLabel.Name = "upJobStartAtLabel";
-            this.upJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
+            this.upJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
             this.upJobStartAtLabel.TabIndex = 2;
             this.upJobStartAtLabel.Text = "start at";
             this.upJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -809,10 +873,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.upJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 48);
+            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 74);
+            this.upJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobStartAtDateTimePicker.Name = "upJobStartAtDateTimePicker";
             this.upJobStartAtDateTimePicker.ShowUpDown = true;
-            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
+            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
             this.upJobStartAtDateTimePicker.TabIndex = 8;
             this.upJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -820,10 +885,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobMinutesDateTimePicker.CustomFormat = "mm";
             this.upJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 48);
+            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 74);
+            this.upJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobMinutesDateTimePicker.Name = "upJobMinutesDateTimePicker";
             this.upJobMinutesDateTimePicker.ShowUpDown = true;
-            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.upJobMinutesDateTimePicker.TabIndex = 7;
             this.upJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -831,54 +897,13 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobHoursDateTimePicker.CustomFormat = "HH";
             this.upJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 48);
+            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 74);
+            this.upJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobHoursDateTimePicker.Name = "upJobHoursDateTimePicker";
             this.upJobHoursDateTimePicker.ShowUpDown = true;
-            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.upJobHoursDateTimePicker.TabIndex = 6;
             this.upJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
-            // 
-            // bottomToolStrip
-            // 
-            this.bottomToolStrip.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.bottomToolStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.bottomToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cancelButton,
-            this.addJobButton,
-            this.customActionsButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 551);
-            this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Size = new System.Drawing.Size(721, 25);
-            this.bottomToolStrip.TabIndex = 7;
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(47, 22);
-            this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
-            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
-            // 
-            // addJobButton
-            // 
-            this.addJobButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(97, 22);
-            this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
-            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
-            // 
-            // customActionsButton
-            // 
-            this.customActionsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.customActionsButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.customActionsButton.Name = "customActionsButton";
-            this.customActionsButton.Size = new System.Drawing.Size(129, 22);
-            this.customActionsButton.Text = "Custom Odata actions";
-            this.customActionsButton.Click += new System.EventHandler(this.CustomActionsButton_Click);
             // 
             // downloadFolderLabel
             // 
@@ -901,9 +926,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingJobGroupBox.Controls.Add(this.procJobMinutesDateTimePicker);
             this.processingJobGroupBox.Controls.Add(this.procJobHoursDateTimePicker);
             this.processingJobGroupBox.Enabled = false;
-            this.processingJobGroupBox.Location = new System.Drawing.Point(250, 367);
+            this.processingJobGroupBox.Location = new System.Drawing.Point(375, 565);
+            this.processingJobGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.processingJobGroupBox.Name = "processingJobGroupBox";
-            this.processingJobGroupBox.Size = new System.Drawing.Size(230, 126);
+            this.processingJobGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingJobGroupBox.Size = new System.Drawing.Size(345, 194);
             this.processingJobGroupBox.TabIndex = 5;
             this.processingJobGroupBox.TabStop = false;
             this.processingJobGroupBox.Text = "Execution monitoring job";
@@ -912,17 +939,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobTriggerTypePanel.Controls.Add(this.procJobCronTriggerRadioButton);
             this.procJobTriggerTypePanel.Controls.Add(this.procJobSimpleTriggerRadioButton);
-            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(9, 48);
+            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(14, 74);
+            this.procJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobTriggerTypePanel.Name = "procJobTriggerTypePanel";
-            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
+            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
             this.procJobTriggerTypePanel.TabIndex = 38;
             // 
             // procJobCronTriggerRadioButton
             // 
             this.procJobCronTriggerRadioButton.AutoSize = true;
-            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 1);
+            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 2);
+            this.procJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobCronTriggerRadioButton.Name = "procJobCronTriggerRadioButton";
-            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
+            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
             this.procJobCronTriggerRadioButton.TabIndex = 1;
             this.procJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.procJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -932,9 +961,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobSimpleTriggerRadioButton.AutoSize = true;
             this.procJobSimpleTriggerRadioButton.Checked = true;
-            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.procJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobSimpleTriggerRadioButton.Name = "procJobSimpleTriggerRadioButton";
-            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
+            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
             this.procJobSimpleTriggerRadioButton.TabIndex = 0;
             this.procJobSimpleTriggerRadioButton.TabStop = true;
             this.procJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -943,28 +973,30 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobCronExpressionLabel
             // 
             this.procJobCronExpressionLabel.AutoSize = true;
-            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(6, 79);
+            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(9, 122);
+            this.procJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.procJobCronExpressionLabel.Name = "procJobCronExpressionLabel";
-            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
+            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
             this.procJobCronExpressionLabel.TabIndex = 3;
             this.procJobCronExpressionLabel.Text = "Cron expression";
             // 
             // procJobCronExpressionTextBox
             // 
             this.procJobCronExpressionTextBox.Enabled = false;
-            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 95);
+            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 146);
+            this.procJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobCronExpressionTextBox.Name = "procJobCronExpressionTextBox";
-            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
+            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
             this.procJobCronExpressionTextBox.TabIndex = 7;
             this.procJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // procJobMinutesLabel
             // 
             this.procJobMinutesLabel.AutoSize = true;
-            this.procJobMinutesLabel.Location = new System.Drawing.Point(64, 25);
+            this.procJobMinutesLabel.Location = new System.Drawing.Point(96, 38);
             this.procJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobMinutesLabel.Name = "procJobMinutesLabel";
-            this.procJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
+            this.procJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
             this.procJobMinutesLabel.TabIndex = 1;
             this.procJobMinutesLabel.Text = "M:";
             this.procJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -972,10 +1004,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobHoursLabel
             // 
             this.procJobHoursLabel.AutoSize = true;
-            this.procJobHoursLabel.Location = new System.Drawing.Point(6, 25);
+            this.procJobHoursLabel.Location = new System.Drawing.Point(9, 38);
             this.procJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobHoursLabel.Name = "procJobHoursLabel";
-            this.procJobHoursLabel.Size = new System.Drawing.Size(18, 13);
+            this.procJobHoursLabel.Size = new System.Drawing.Size(25, 20);
             this.procJobHoursLabel.TabIndex = 0;
             this.procJobHoursLabel.Text = "H:";
             this.procJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -983,9 +1015,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobStartAtLabel
             // 
             this.procJobStartAtLabel.AutoSize = true;
-            this.procJobStartAtLabel.Location = new System.Drawing.Point(126, 25);
+            this.procJobStartAtLabel.Location = new System.Drawing.Point(189, 38);
+            this.procJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.procJobStartAtLabel.Name = "procJobStartAtLabel";
-            this.procJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
+            this.procJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
             this.procJobStartAtLabel.TabIndex = 2;
             this.procJobStartAtLabel.Text = "start at";
             this.procJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -994,10 +1027,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.procJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 22);
+            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 34);
+            this.procJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobStartAtDateTimePicker.Name = "procJobStartAtDateTimePicker";
             this.procJobStartAtDateTimePicker.ShowUpDown = true;
-            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
+            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
             this.procJobStartAtDateTimePicker.TabIndex = 6;
             this.procJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -1005,10 +1039,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobMinutesDateTimePicker.CustomFormat = "mm";
             this.procJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 22);
+            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 34);
+            this.procJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobMinutesDateTimePicker.Name = "procJobMinutesDateTimePicker";
             this.procJobMinutesDateTimePicker.ShowUpDown = true;
-            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.procJobMinutesDateTimePicker.TabIndex = 5;
             this.procJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 30, 0, 0);
             // 
@@ -1016,19 +1051,21 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobHoursDateTimePicker.CustomFormat = "HH";
             this.procJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 22);
+            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 34);
+            this.procJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobHoursDateTimePicker.Name = "procJobHoursDateTimePicker";
             this.procJobHoursDateTimePicker.ShowUpDown = true;
-            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.procJobHoursDateTimePicker.TabIndex = 4;
             this.procJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
             // useMonitoringJobCheckBox
             // 
             this.useMonitoringJobCheckBox.AutoSize = true;
-            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(249, 348);
+            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(374, 535);
+            this.useMonitoringJobCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.useMonitoringJobCheckBox.Name = "useMonitoringJobCheckBox";
-            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(113, 17);
+            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(167, 24);
             this.useMonitoringJobCheckBox.TabIndex = 4;
             this.useMonitoringJobCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_monitoring_job;
             this.useMonitoringJobCheckBox.UseVisualStyleBackColor = true;
@@ -1042,11 +1079,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.fileSelectionGroupBox.Controls.Add(this.orderLabel);
             this.fileSelectionGroupBox.Controls.Add(this.orderByLabel);
             this.fileSelectionGroupBox.Controls.Add(this.searchPatternLabel);
-            this.fileSelectionGroupBox.Location = new System.Drawing.Point(250, 111);
-            this.fileSelectionGroupBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.fileSelectionGroupBox.Location = new System.Drawing.Point(375, 171);
+            this.fileSelectionGroupBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.fileSelectionGroupBox.Name = "fileSelectionGroupBox";
-            this.fileSelectionGroupBox.Padding = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.fileSelectionGroupBox.Size = new System.Drawing.Size(229, 97);
+            this.fileSelectionGroupBox.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.fileSelectionGroupBox.Size = new System.Drawing.Size(344, 149);
             this.fileSelectionGroupBox.TabIndex = 2;
             this.fileSelectionGroupBox.TabStop = false;
             this.fileSelectionGroupBox.Text = "Files filter and order";
@@ -1055,29 +1092,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderByComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.orderByComboBox.FormattingEnabled = true;
-            this.orderByComboBox.Location = new System.Drawing.Point(58, 40);
-            this.orderByComboBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.orderByComboBox.Location = new System.Drawing.Point(87, 62);
+            this.orderByComboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.orderByComboBox.Name = "orderByComboBox";
-            this.orderByComboBox.Size = new System.Drawing.Size(168, 21);
+            this.orderByComboBox.Size = new System.Drawing.Size(250, 28);
             this.orderByComboBox.TabIndex = 4;
             // 
             // panel1
             // 
             this.panel1.Controls.Add(this.orderDescendingRadioButton);
             this.panel1.Controls.Add(this.orderAscendingRadioButton);
-            this.panel1.Location = new System.Drawing.Point(43, 66);
+            this.panel1.Location = new System.Drawing.Point(64, 102);
             this.panel1.Margin = new System.Windows.Forms.Padding(0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(181, 23);
+            this.panel1.Size = new System.Drawing.Size(272, 35);
             this.panel1.TabIndex = 4;
             // 
             // orderDescendingRadioButton
             // 
             this.orderDescendingRadioButton.AutoSize = true;
-            this.orderDescendingRadioButton.Location = new System.Drawing.Point(101, 3);
+            this.orderDescendingRadioButton.Location = new System.Drawing.Point(152, 5);
             this.orderDescendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderDescendingRadioButton.Name = "orderDescendingRadioButton";
-            this.orderDescendingRadioButton.Size = new System.Drawing.Size(82, 17);
+            this.orderDescendingRadioButton.Size = new System.Drawing.Size(119, 24);
             this.orderDescendingRadioButton.TabIndex = 1;
             this.orderDescendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Descending;
             this.orderDescendingRadioButton.UseVisualStyleBackColor = true;
@@ -1086,10 +1123,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderAscendingRadioButton.AutoSize = true;
             this.orderAscendingRadioButton.Checked = true;
-            this.orderAscendingRadioButton.Location = new System.Drawing.Point(4, 3);
+            this.orderAscendingRadioButton.Location = new System.Drawing.Point(6, 5);
             this.orderAscendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderAscendingRadioButton.Name = "orderAscendingRadioButton";
-            this.orderAscendingRadioButton.Size = new System.Drawing.Size(75, 17);
+            this.orderAscendingRadioButton.Size = new System.Drawing.Size(109, 24);
             this.orderAscendingRadioButton.TabIndex = 0;
             this.orderAscendingRadioButton.TabStop = true;
             this.orderAscendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Ascending;
@@ -1097,40 +1134,37 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // searchPatternTextBox
             // 
-            this.searchPatternTextBox.Location = new System.Drawing.Point(85, 18);
-            this.searchPatternTextBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.searchPatternTextBox.Location = new System.Drawing.Point(128, 28);
+            this.searchPatternTextBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.searchPatternTextBox.Name = "searchPatternTextBox";
-            this.searchPatternTextBox.Size = new System.Drawing.Size(141, 20);
+            this.searchPatternTextBox.Size = new System.Drawing.Size(210, 26);
             this.searchPatternTextBox.TabIndex = 3;
             this.searchPatternTextBox.Text = "*.zip";
             // 
             // orderLabel
             // 
             this.orderLabel.AutoSize = true;
-            this.orderLabel.Location = new System.Drawing.Point(5, 66);
-            this.orderLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.orderLabel.Location = new System.Drawing.Point(8, 102);
             this.orderLabel.Name = "orderLabel";
-            this.orderLabel.Size = new System.Drawing.Size(33, 13);
+            this.orderLabel.Size = new System.Drawing.Size(49, 20);
             this.orderLabel.TabIndex = 2;
             this.orderLabel.Text = "Order";
             // 
             // orderByLabel
             // 
             this.orderByLabel.AutoSize = true;
-            this.orderByLabel.Location = new System.Drawing.Point(5, 43);
-            this.orderByLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.orderByLabel.Location = new System.Drawing.Point(8, 66);
             this.orderByLabel.Name = "orderByLabel";
-            this.orderByLabel.Size = new System.Drawing.Size(47, 13);
+            this.orderByLabel.Size = new System.Drawing.Size(69, 20);
             this.orderByLabel.TabIndex = 1;
             this.orderByLabel.Text = "Order by";
             // 
             // searchPatternLabel
             // 
             this.searchPatternLabel.AutoSize = true;
-            this.searchPatternLabel.Location = new System.Drawing.Point(5, 20);
-            this.searchPatternLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.searchPatternLabel.Location = new System.Drawing.Point(8, 31);
             this.searchPatternLabel.Name = "searchPatternLabel";
-            this.searchPatternLabel.Size = new System.Drawing.Size(77, 13);
+            this.searchPatternLabel.Size = new System.Drawing.Size(115, 20);
             this.searchPatternLabel.TabIndex = 0;
             this.searchPatternLabel.Text = "Search pattern";
             // 
@@ -1140,11 +1174,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.importDetailsGroupBox.Controls.Add(this.overwriteDataProjectCheckBox);
             this.importDetailsGroupBox.Controls.Add(this.dataProject);
             this.importDetailsGroupBox.Controls.Add(this.dataProjectLabel);
-            this.importDetailsGroupBox.Location = new System.Drawing.Point(249, 19);
-            this.importDetailsGroupBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.importDetailsGroupBox.Location = new System.Drawing.Point(374, 29);
+            this.importDetailsGroupBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.importDetailsGroupBox.Name = "importDetailsGroupBox";
-            this.importDetailsGroupBox.Padding = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.importDetailsGroupBox.Size = new System.Drawing.Size(229, 84);
+            this.importDetailsGroupBox.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.importDetailsGroupBox.Size = new System.Drawing.Size(344, 129);
             this.importDetailsGroupBox.TabIndex = 1;
             this.importDetailsGroupBox.TabStop = false;
             this.importDetailsGroupBox.Text = "Import details";
@@ -1154,9 +1188,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.executeImportCheckBox.AutoSize = true;
             this.executeImportCheckBox.Checked = true;
             this.executeImportCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.executeImportCheckBox.Location = new System.Drawing.Point(7, 65);
+            this.executeImportCheckBox.Location = new System.Drawing.Point(10, 100);
+            this.executeImportCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.executeImportCheckBox.Name = "executeImportCheckBox";
-            this.executeImportCheckBox.Size = new System.Drawing.Size(96, 17);
+            this.executeImportCheckBox.Size = new System.Drawing.Size(141, 24);
             this.executeImportCheckBox.TabIndex = 3;
             this.executeImportCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Execute_import;
             this.executeImportCheckBox.UseVisualStyleBackColor = true;
@@ -1166,28 +1201,28 @@ namespace RecurringIntegrationsScheduler.Forms
             this.overwriteDataProjectCheckBox.AutoSize = true;
             this.overwriteDataProjectCheckBox.Checked = true;
             this.overwriteDataProjectCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.overwriteDataProjectCheckBox.Location = new System.Drawing.Point(7, 42);
+            this.overwriteDataProjectCheckBox.Location = new System.Drawing.Point(10, 65);
+            this.overwriteDataProjectCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.overwriteDataProjectCheckBox.Name = "overwriteDataProjectCheckBox";
-            this.overwriteDataProjectCheckBox.Size = new System.Drawing.Size(175, 17);
+            this.overwriteDataProjectCheckBox.Size = new System.Drawing.Size(257, 24);
             this.overwriteDataProjectCheckBox.TabIndex = 2;
             this.overwriteDataProjectCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Overwrite_data_project_definition;
             this.overwriteDataProjectCheckBox.UseVisualStyleBackColor = true;
             // 
             // dataProject
             // 
-            this.dataProject.Location = new System.Drawing.Point(85, 18);
-            this.dataProject.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.dataProject.Location = new System.Drawing.Point(128, 28);
+            this.dataProject.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.dataProject.Name = "dataProject";
-            this.dataProject.Size = new System.Drawing.Size(141, 20);
+            this.dataProject.Size = new System.Drawing.Size(210, 26);
             this.dataProject.TabIndex = 1;
             // 
             // dataProjectLabel
             // 
             this.dataProjectLabel.AutoSize = true;
-            this.dataProjectLabel.Location = new System.Drawing.Point(5, 20);
-            this.dataProjectLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.dataProjectLabel.Location = new System.Drawing.Point(8, 31);
             this.dataProjectLabel.Name = "dataProjectLabel";
-            this.dataProjectLabel.Size = new System.Drawing.Size(65, 13);
+            this.dataProjectLabel.Size = new System.Drawing.Size(96, 20);
             this.dataProjectLabel.TabIndex = 0;
             this.dataProjectLabel.Text = "Data project";
             // 
@@ -1201,23 +1236,26 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(486, 478);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(729, 735);
+            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 67);
+            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 103);
             this.retryPolicyGroupBox.TabIndex = 8;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(99, 42);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(148, 65);
+            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesDelayUpDown.TabIndex = 10;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -1228,22 +1266,24 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(7, 44);
+            this.label2.Location = new System.Drawing.Point(10, 68);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 13);
+            this.label2.Size = new System.Drawing.Size(123, 20);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(99, 18);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(148, 28);
+            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesCountUpDown.TabIndex = 9;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -1254,20 +1294,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(7, 20);
+            this.label1.Location = new System.Drawing.Point(10, 31);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(87, 13);
+            this.label1.Size = new System.Drawing.Size(131, 20);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(250, 498);
-            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(375, 766);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 51);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 72);
             this.groupBoxExceptions.TabIndex = 9;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -1277,32 +1316,61 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
-            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(14, 26);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
-            // pauseIndefinitelyCheckBox
+            // groupBoxButtons
             // 
-            this.pauseIndefinitelyCheckBox.AutoSize = true;
-            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(10, 19);
-            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
-            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
-            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
-            this.pauseIndefinitelyCheckBox.TabIndex = 0;
-            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
-            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            this.groupBoxButtons.Controls.Add(this.addJobButton);
+            this.groupBoxButtons.Controls.Add(this.cancelButton);
+            this.groupBoxButtons.Controls.Add(this.customActionsButton);
+            this.groupBoxButtons.Location = new System.Drawing.Point(20, 844);
+            this.groupBoxButtons.Name = "groupBoxButtons";
+            this.groupBoxButtons.Size = new System.Drawing.Size(1055, 71);
+            this.groupBoxButtons.TabIndex = 10;
+            this.groupBoxButtons.TabStop = false;
+            // 
+            // addJobButton
+            // 
+            this.addJobButton.Location = new System.Drawing.Point(709, 25);
+            this.addJobButton.Name = "addJobButton";
+            this.addJobButton.Size = new System.Drawing.Size(162, 34);
+            this.addJobButton.TabIndex = 2;
+            this.addJobButton.Text = "Add to schedule";
+            this.addJobButton.UseVisualStyleBackColor = true;
+            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.Location = new System.Drawing.Point(887, 25);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(162, 34);
+            this.cancelButton.TabIndex = 1;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
+            // 
+            // customActionsButton
+            // 
+            this.customActionsButton.Location = new System.Drawing.Point(6, 25);
+            this.customActionsButton.Name = "customActionsButton";
+            this.customActionsButton.Size = new System.Drawing.Size(288, 34);
+            this.customActionsButton.TabIndex = 0;
+            this.customActionsButton.Text = "Custom Odata actions";
+            this.customActionsButton.UseVisualStyleBackColor = true;
+            this.customActionsButton.Click += new System.EventHandler(this.CustomActionsButton_Click);
             // 
             // ImportJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(721, 576);
-            this.Controls.Add(this.bottomToolStrip);
+            this.ClientSize = new System.Drawing.Size(1082, 927);
+            this.Controls.Add(this.groupBoxButtons);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.importDetailsGroupBox);
             this.Controls.Add(this.fileSelectionGroupBox);
@@ -1313,9 +1381,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.Controls.Add(this.useMonitoringJobCheckBox);
             this.Controls.Add(this.retryPolicyGroupBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(737, 615);
+            this.MinimumSize = new System.Drawing.Size(1094, 916);
             this.Name = "ImportJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -1332,8 +1401,6 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.PerformLayout();
             this.upJobTriggerTypePanel.ResumeLayout(false);
             this.upJobTriggerTypePanel.PerformLayout();
-            this.bottomToolStrip.ResumeLayout(false);
-            this.bottomToolStrip.PerformLayout();
             this.processingJobGroupBox.ResumeLayout(false);
             this.processingJobGroupBox.PerformLayout();
             this.procJobTriggerTypePanel.ResumeLayout(false);
@@ -1350,6 +1417,7 @@ namespace RecurringIntegrationsScheduler.Forms
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).EndInit();
             this.groupBoxExceptions.ResumeLayout(false);
             this.groupBoxExceptions.PerformLayout();
+            this.groupBoxButtons.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1392,7 +1460,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.Panel upJobTriggerTypePanel;
         private System.Windows.Forms.RadioButton upJobCronTriggerRadioButton;
         private System.Windows.Forms.RadioButton upJobSimpleTriggerRadioButton;
-        private System.Windows.Forms.ToolStrip bottomToolStrip;
         private System.Windows.Forms.LinkLabel cronDocsLinkLabel;
         private System.Windows.Forms.TextBox calculatedRunsTextBox;
         private System.Windows.Forms.Button getCronScheduleForUploadButton;
@@ -1420,8 +1487,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.DateTimePicker procJobStartAtDateTimePicker;
         private System.Windows.Forms.DateTimePicker procJobMinutesDateTimePicker;
         private System.Windows.Forms.DateTimePicker procJobHoursDateTimePicker;
-        private System.Windows.Forms.ToolStripButton addJobButton;
-        private System.Windows.Forms.ToolStripButton cancelButton;
         private System.Windows.Forms.Button getCronScheduleForProcButton;
         private System.Windows.Forms.Label LegalEntityLabel;
         private System.Windows.Forms.TextBox statusFileExtensionTextBox;
@@ -1460,7 +1525,10 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.NumericUpDown retriesCountUpDown;
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
-        private System.Windows.Forms.ToolStripButton customActionsButton;
         private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
+        private System.Windows.Forms.GroupBox groupBoxButtons;
+        private System.Windows.Forms.Button addJobButton;
+        private System.Windows.Forms.Button cancelButton;
+        private System.Windows.Forms.Button customActionsButton;
     }
 }

--- a/Scheduler/Forms/ImportJob.Designer.cs
+++ b/Scheduler/Forms/ImportJob.Designer.cs
@@ -135,6 +135,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.groupBoxExceptions = new System.Windows.Forms.GroupBox();
             this.pauseOnExceptionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
             this.jobDetailsGroupBox.SuspendLayout();
             this.axDetailsGroupBox.SuspendLayout();
             this.authMethodPanel.SuspendLayout();
@@ -186,11 +187,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
-            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(344, 738);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(229, 480);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -199,10 +198,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.PackageTemplateFileBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.PackageTemplateFileBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.PackageTemplateFileBrowserButton.Location = new System.Drawing.Point(300, 622);
+            this.PackageTemplateFileBrowserButton.Location = new System.Drawing.Point(200, 404);
             this.PackageTemplateFileBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.PackageTemplateFileBrowserButton.Name = "PackageTemplateFileBrowserButton";
-            this.PackageTemplateFileBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.PackageTemplateFileBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.PackageTemplateFileBrowserButton.TabIndex = 29;
             this.PackageTemplateFileBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.PackageTemplateFileBrowserButton.UseVisualStyleBackColor = true;
@@ -210,19 +209,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // packageTemplateTextBox
             // 
-            this.packageTemplateTextBox.Location = new System.Drawing.Point(16, 628);
-            this.packageTemplateTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.packageTemplateTextBox.Location = new System.Drawing.Point(11, 408);
             this.packageTemplateTextBox.Name = "packageTemplateTextBox";
-            this.packageTemplateTextBox.Size = new System.Drawing.Size(278, 26);
+            this.packageTemplateTextBox.Size = new System.Drawing.Size(187, 20);
             this.packageTemplateTextBox.TabIndex = 28;
             // 
             // PackageTemplateLabel
             // 
             this.PackageTemplateLabel.AutoSize = true;
-            this.PackageTemplateLabel.Location = new System.Drawing.Point(12, 602);
-            this.PackageTemplateLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.PackageTemplateLabel.Location = new System.Drawing.Point(8, 391);
             this.PackageTemplateLabel.Name = "PackageTemplateLabel";
-            this.PackageTemplateLabel.Size = new System.Drawing.Size(137, 20);
+            this.PackageTemplateLabel.Size = new System.Drawing.Size(93, 13);
             this.PackageTemplateLabel.TabIndex = 10;
             this.PackageTemplateLabel.Text = "Package template";
             // 
@@ -231,10 +228,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingErrorsFolderBrowserButton.Enabled = false;
             this.processingErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 566);
+            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 368);
             this.processingErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingErrorsFolderBrowserButton.Name = "processingErrorsFolderBrowserButton";
-            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.processingErrorsFolderBrowserButton.TabIndex = 27;
             this.processingErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -243,29 +240,26 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingErrorsFolderTextBox
             // 
             this.processingErrorsFolderTextBox.Enabled = false;
-            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(16, 572);
-            this.processingErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(11, 372);
             this.processingErrorsFolderTextBox.Name = "processingErrorsFolderTextBox";
-            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.processingErrorsFolderTextBox.TabIndex = 26;
             // 
             // processingErrorsFolderLabel
             // 
             this.processingErrorsFolderLabel.AutoSize = true;
-            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(12, 545);
-            this.processingErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(8, 354);
             this.processingErrorsFolderLabel.Name = "processingErrorsFolderLabel";
-            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(176, 20);
+            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(117, 13);
             this.processingErrorsFolderLabel.TabIndex = 9;
             this.processingErrorsFolderLabel.Text = "Processing errors folder";
             // 
             // statusFileExtensionTextBox
             // 
             this.statusFileExtensionTextBox.Enabled = false;
-            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(218, 702);
-            this.statusFileExtensionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(145, 456);
             this.statusFileExtensionTextBox.Name = "statusFileExtensionTextBox";
-            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(120, 26);
+            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(81, 20);
             this.statusFileExtensionTextBox.TabIndex = 31;
             this.statusFileExtensionTextBox.Text = ".Status";
             this.statusFileExtensionTextBox.Leave += new System.EventHandler(this.StatusFileExtensionTextBox_Leave);
@@ -273,28 +267,25 @@ namespace RecurringIntegrationsScheduler.Forms
             // statusFileExtensionLabel
             // 
             this.statusFileExtensionLabel.AutoSize = true;
-            this.statusFileExtensionLabel.Location = new System.Drawing.Point(57, 708);
-            this.statusFileExtensionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.statusFileExtensionLabel.Location = new System.Drawing.Point(38, 460);
             this.statusFileExtensionLabel.Name = "statusFileExtensionLabel";
-            this.statusFileExtensionLabel.Size = new System.Drawing.Size(152, 20);
+            this.statusFileExtensionLabel.Size = new System.Drawing.Size(101, 13);
             this.statusFileExtensionLabel.TabIndex = 12;
             this.statusFileExtensionLabel.Text = "Status file extension";
             // 
             // legalEntityTextBox
             // 
-            this.legalEntityTextBox.Location = new System.Drawing.Point(218, 666);
-            this.legalEntityTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.legalEntityTextBox.Location = new System.Drawing.Point(145, 433);
             this.legalEntityTextBox.Name = "legalEntityTextBox";
-            this.legalEntityTextBox.Size = new System.Drawing.Size(120, 26);
+            this.legalEntityTextBox.Size = new System.Drawing.Size(81, 20);
             this.legalEntityTextBox.TabIndex = 30;
             // 
             // LegalEntityLabel
             // 
             this.LegalEntityLabel.AutoSize = true;
-            this.LegalEntityLabel.Location = new System.Drawing.Point(118, 669);
-            this.LegalEntityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LegalEntityLabel.Location = new System.Drawing.Point(79, 435);
             this.LegalEntityLabel.Name = "LegalEntityLabel";
-            this.LegalEntityLabel.Size = new System.Drawing.Size(90, 20);
+            this.LegalEntityLabel.Size = new System.Drawing.Size(61, 13);
             this.LegalEntityLabel.TabIndex = 11;
             this.LegalEntityLabel.Text = "Legal entity";
             // 
@@ -303,10 +294,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.inputFolderBrowserButton.Enabled = false;
             this.inputFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.inputFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.inputFolderBrowserButton.Location = new System.Drawing.Point(300, 322);
+            this.inputFolderBrowserButton.Location = new System.Drawing.Point(200, 209);
             this.inputFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.inputFolderBrowserButton.Name = "inputFolderBrowserButton";
-            this.inputFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.inputFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.inputFolderBrowserButton.TabIndex = 19;
             this.inputFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.inputFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -315,19 +306,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // inputFolderTextBox
             // 
             this.inputFolderTextBox.Enabled = false;
-            this.inputFolderTextBox.Location = new System.Drawing.Point(16, 328);
-            this.inputFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.inputFolderTextBox.Location = new System.Drawing.Point(11, 213);
             this.inputFolderTextBox.Name = "inputFolderTextBox";
-            this.inputFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.inputFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.inputFolderTextBox.TabIndex = 18;
             // 
             // inputFolderLabel
             // 
             this.inputFolderLabel.AutoSize = true;
-            this.inputFolderLabel.Location = new System.Drawing.Point(12, 300);
-            this.inputFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.inputFolderLabel.Location = new System.Drawing.Point(8, 195);
             this.inputFolderLabel.Name = "inputFolderLabel";
-            this.inputFolderLabel.Size = new System.Drawing.Size(116, 20);
+            this.inputFolderLabel.Size = new System.Drawing.Size(77, 13);
             this.inputFolderLabel.TabIndex = 5;
             this.inputFolderLabel.Text = "Input subfolder";
             // 
@@ -336,10 +325,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingSuccessFolderBrowserButton.Enabled = false;
             this.processingSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 505);
+            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 328);
             this.processingSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingSuccessFolderBrowserButton.Name = "processingSuccessFolderBrowserButton";
-            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.processingSuccessFolderBrowserButton.TabIndex = 25;
             this.processingSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -348,19 +337,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingSuccessFolderTextBox
             // 
             this.processingSuccessFolderTextBox.Enabled = false;
-            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(16, 511);
-            this.processingSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(11, 332);
             this.processingSuccessFolderTextBox.Name = "processingSuccessFolderTextBox";
-            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.processingSuccessFolderTextBox.TabIndex = 24;
             // 
             // processingSuccessFolderLabel
             // 
             this.processingSuccessFolderLabel.AutoSize = true;
-            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(12, 485);
-            this.processingSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(8, 315);
             this.processingSuccessFolderLabel.Name = "processingSuccessFolderLabel";
-            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(193, 20);
+            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(130, 13);
             this.processingSuccessFolderLabel.TabIndex = 8;
             this.processingSuccessFolderLabel.Text = "Processing success folder";
             // 
@@ -369,10 +356,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadSuccessFolderBrowserButton.Enabled = false;
             this.uploadSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 382);
+            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 248);
             this.uploadSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadSuccessFolderBrowserButton.Name = "uploadSuccessFolderBrowserButton";
-            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.uploadSuccessFolderBrowserButton.TabIndex = 21;
             this.uploadSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -381,19 +368,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadSuccessFolderTextBox
             // 
             this.uploadSuccessFolderTextBox.Enabled = false;
-            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(16, 389);
-            this.uploadSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(11, 253);
             this.uploadSuccessFolderTextBox.Name = "uploadSuccessFolderTextBox";
-            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.uploadSuccessFolderTextBox.TabIndex = 20;
             // 
             // uploadSuccessFolderLabel
             // 
             this.uploadSuccessFolderLabel.AutoSize = true;
-            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(12, 362);
-            this.uploadSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(8, 235);
             this.uploadSuccessFolderLabel.Name = "uploadSuccessFolderLabel";
-            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(166, 20);
+            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(112, 13);
             this.uploadSuccessFolderLabel.TabIndex = 6;
             this.uploadSuccessFolderLabel.Text = "Upload success folder";
             // 
@@ -402,10 +387,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(16, 268);
-            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(11, 174);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(247, 24);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(165, 17);
             this.useStandardSubfolder.TabIndex = 4;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_subfolders_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -416,10 +400,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadErrorsFolderBrowserButton.Enabled = false;
             this.uploadErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 445);
+            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 289);
             this.uploadErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadErrorsFolderBrowserButton.Name = "uploadErrorsFolderBrowserButton";
-            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.uploadErrorsFolderBrowserButton.TabIndex = 23;
             this.uploadErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -428,19 +412,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadErrorsFolderTextBox
             // 
             this.uploadErrorsFolderTextBox.Enabled = false;
-            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(16, 449);
-            this.uploadErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(11, 292);
             this.uploadErrorsFolderTextBox.Name = "uploadErrorsFolderTextBox";
-            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.uploadErrorsFolderTextBox.TabIndex = 22;
             // 
             // uploadErrorsFolderLabel
             // 
             this.uploadErrorsFolderLabel.AutoSize = true;
-            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(12, 422);
-            this.uploadErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(8, 274);
             this.uploadErrorsFolderLabel.Name = "uploadErrorsFolderLabel";
-            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(149, 20);
+            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(99, 13);
             this.uploadErrorsFolderLabel.TabIndex = 7;
             this.uploadErrorsFolderLabel.Text = "Upload errors folder";
             // 
@@ -448,10 +430,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.topUploadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.topUploadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(300, 228);
+            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(200, 148);
             this.topUploadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.topUploadFolderBrowserButton.Name = "topUploadFolderBrowserButton";
-            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.topUploadFolderBrowserButton.TabIndex = 17;
             this.topUploadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.topUploadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -459,39 +441,35 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // topUploadFolderTextBox
             // 
-            this.topUploadFolderTextBox.Location = new System.Drawing.Point(16, 234);
-            this.topUploadFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.topUploadFolderTextBox.Location = new System.Drawing.Point(11, 152);
             this.topUploadFolderTextBox.Name = "topUploadFolderTextBox";
-            this.topUploadFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.topUploadFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.topUploadFolderTextBox.TabIndex = 16;
             this.topUploadFolderTextBox.TextChanged += new System.EventHandler(this.TopUploadFolder_TextChanged);
             // 
             // topUploadFolderLabel
             // 
             this.topUploadFolderLabel.AutoSize = true;
-            this.topUploadFolderLabel.Location = new System.Drawing.Point(12, 206);
-            this.topUploadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.topUploadFolderLabel.Location = new System.Drawing.Point(8, 134);
             this.topUploadFolderLabel.Name = "topUploadFolderLabel";
-            this.topUploadFolderLabel.Size = new System.Drawing.Size(132, 20);
+            this.topUploadFolderLabel.Size = new System.Drawing.Size(90, 13);
             this.topUploadFolderLabel.TabIndex = 3;
             this.topUploadFolderLabel.Text = "Top upload folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(18, 145);
-            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDescription.Location = new System.Drawing.Point(12, 94);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(314, 53);
+            this.jobDescription.Size = new System.Drawing.Size(211, 36);
             this.jobDescription.TabIndex = 15;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(12, 118);
-            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(8, 77);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
             this.jobDescriptionLabel.TabIndex = 2;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -499,38 +477,34 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
-            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 14;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(12, 80);
-            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobGroupLabel.Location = new System.Drawing.Point(8, 52);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
+            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
             this.jobGroupLabel.TabIndex = 1;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(75, 26);
-            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobName.Location = new System.Drawing.Point(50, 17);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(258, 26);
+            this.jobName.Size = new System.Drawing.Size(173, 20);
             this.jobName.TabIndex = 13;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(12, 31);
-            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobNameLabel.Location = new System.Drawing.Point(8, 20);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
+            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -543,11 +517,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(375, 325);
-            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(250, 211);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 202);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 131);
             this.axDetailsGroupBox.TabIndex = 3;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -555,10 +527,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(18, 122);
-            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(12, 79);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
             this.aadApplicationLabel.TabIndex = 1;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -566,29 +537,26 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(154, 118);
-            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(103, 77);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(180, 28);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(121, 21);
             this.aadApplicationComboBox.TabIndex = 4;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(10, 69);
-            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.authMethodPanel.Location = new System.Drawing.Point(7, 45);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(322, 38);
+            this.authMethodPanel.Size = new System.Drawing.Size(215, 25);
             this.authMethodPanel.TabIndex = 30;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
-            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
             this.serviceAuthRadioButton.TabIndex = 1;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -598,10 +566,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
             this.userAuthRadioButton.TabIndex = 0;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -610,10 +577,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(98, 162);
-            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.userLabel.Location = new System.Drawing.Point(65, 105);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(43, 20);
+            this.userLabel.Size = new System.Drawing.Size(29, 13);
             this.userLabel.TabIndex = 2;
             this.userLabel.Text = "User";
             // 
@@ -621,19 +587,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(154, 158);
-            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userComboBox.Location = new System.Drawing.Point(103, 103);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(180, 28);
+            this.userComboBox.Size = new System.Drawing.Size(121, 21);
             this.userComboBox.TabIndex = 5;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(28, 34);
-            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.instanceLabel.Location = new System.Drawing.Point(19, 22);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
+            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
             this.instanceLabel.TabIndex = 0;
             this.instanceLabel.Text = "Instance";
             // 
@@ -641,14 +605,14 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(114, 29);
-            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.instanceComboBox.Location = new System.Drawing.Point(76, 19);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
+            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
             this.instanceComboBox.TabIndex = 3;
             // 
             // recurrenceGroupBox
             // 
+            this.recurrenceGroupBox.Controls.Add(this.pauseIndefinitelyCheckBox);
             this.recurrenceGroupBox.Controls.Add(this.getCronScheduleForProcButton);
             this.recurrenceGroupBox.Controls.Add(this.moreExamplesButton);
             this.recurrenceGroupBox.Controls.Add(this.calculatedRunsTextBox);
@@ -666,11 +630,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.upJobStartAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobMinutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobHoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(729, 20);
-            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(486, 13);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 634);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 448);
             this.recurrenceGroupBox.TabIndex = 6;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
@@ -678,10 +640,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // getCronScheduleForProcButton
             // 
             this.getCronScheduleForProcButton.Enabled = false;
-            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(178, 472);
-            this.getCronScheduleForProcButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(119, 336);
             this.getCronScheduleForProcButton.Name = "getCronScheduleForProcButton";
-            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(158, 55);
+            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(105, 36);
             this.getCronScheduleForProcButton.TabIndex = 13;
             this.getCronScheduleForProcButton.Text = "Get cron schedule for monitoring job ";
             this.getCronScheduleForProcButton.UseVisualStyleBackColor = true;
@@ -689,10 +650,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(237, 534);
-            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.moreExamplesButton.Location = new System.Drawing.Point(158, 376);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(99, 85);
+            this.moreExamplesButton.Size = new System.Drawing.Size(66, 55);
             this.moreExamplesButton.TabIndex = 15;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -701,22 +661,20 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(14, 534);
-            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 376);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 82);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 55);
             this.calculatedRunsTextBox.TabIndex = 14;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // getCronScheduleForUploadButton
             // 
             this.getCronScheduleForUploadButton.Enabled = false;
-            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(14, 472);
-            this.getCronScheduleForUploadButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(9, 336);
             this.getCronScheduleForUploadButton.Name = "getCronScheduleForUploadButton";
-            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(158, 55);
+            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(105, 36);
             this.getCronScheduleForUploadButton.TabIndex = 12;
             this.getCronScheduleForUploadButton.Text = "Get cron schedule for import job ";
             this.getCronScheduleForUploadButton.UseVisualStyleBackColor = true;
@@ -725,10 +683,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 442);
-            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 316);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
             this.cronDocsLinkLabel.TabIndex = 11;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -738,19 +695,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobTriggerTypePanel.Controls.Add(this.upJobCronTriggerRadioButton);
             this.upJobTriggerTypePanel.Controls.Add(this.upJobSimpleTriggerRadioButton);
-            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(14, 69);
-            this.upJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(9, 74);
             this.upJobTriggerTypePanel.Name = "upJobTriggerTypePanel";
-            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
+            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
             this.upJobTriggerTypePanel.TabIndex = 29;
             // 
             // upJobCronTriggerRadioButton
             // 
             this.upJobCronTriggerRadioButton.AutoSize = true;
-            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 5);
-            this.upJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 3);
             this.upJobCronTriggerRadioButton.Name = "upJobCronTriggerRadioButton";
-            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
+            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
             this.upJobCronTriggerRadioButton.TabIndex = 1;
             this.upJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.upJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -760,10 +715,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobSimpleTriggerRadioButton.AutoSize = true;
             this.upJobSimpleTriggerRadioButton.Checked = true;
-            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.upJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
             this.upJobSimpleTriggerRadioButton.Name = "upJobSimpleTriggerRadioButton";
-            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
+            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
             this.upJobSimpleTriggerRadioButton.TabIndex = 0;
             this.upJobSimpleTriggerRadioButton.TabStop = true;
             this.upJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -772,10 +726,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(9, 412);
-            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.buildCronLabel.Location = new System.Drawing.Point(6, 297);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
+            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
             this.buildCronLabel.TabIndex = 5;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -783,11 +736,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 182);
-            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 147);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(322, 226);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(215, 147);
             this.cronTriggerInfoTextBox.TabIndex = 4;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -795,10 +747,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(189, 412);
-            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(126, 297);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
             this.cronmakerLinkLabel.TabIndex = 10;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -807,30 +758,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobCronExpressionLabel
             // 
             this.upJobCronExpressionLabel.AutoSize = true;
-            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(9, 118);
-            this.upJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(6, 106);
             this.upJobCronExpressionLabel.Name = "upJobCronExpressionLabel";
-            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
+            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
             this.upJobCronExpressionLabel.TabIndex = 3;
             this.upJobCronExpressionLabel.Text = "Cron expression";
             // 
             // upJobCronExpressionTextBox
             // 
             this.upJobCronExpressionTextBox.Enabled = false;
-            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 142);
-            this.upJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 121);
             this.upJobCronExpressionTextBox.Name = "upJobCronExpressionTextBox";
-            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
+            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
             this.upJobCronExpressionTextBox.TabIndex = 9;
             this.upJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // upJobMinutesLabel
             // 
             this.upJobMinutesLabel.AutoSize = true;
-            this.upJobMinutesLabel.Location = new System.Drawing.Point(96, 34);
+            this.upJobMinutesLabel.Location = new System.Drawing.Point(64, 51);
             this.upJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobMinutesLabel.Name = "upJobMinutesLabel";
-            this.upJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
+            this.upJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
             this.upJobMinutesLabel.TabIndex = 1;
             this.upJobMinutesLabel.Text = "M:";
             this.upJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -838,10 +787,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobHoursLabel
             // 
             this.upJobHoursLabel.AutoSize = true;
-            this.upJobHoursLabel.Location = new System.Drawing.Point(9, 34);
+            this.upJobHoursLabel.Location = new System.Drawing.Point(6, 51);
             this.upJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobHoursLabel.Name = "upJobHoursLabel";
-            this.upJobHoursLabel.Size = new System.Drawing.Size(25, 20);
+            this.upJobHoursLabel.Size = new System.Drawing.Size(18, 13);
             this.upJobHoursLabel.TabIndex = 0;
             this.upJobHoursLabel.Text = "H:";
             this.upJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -849,10 +798,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobStartAtLabel
             // 
             this.upJobStartAtLabel.AutoSize = true;
-            this.upJobStartAtLabel.Location = new System.Drawing.Point(189, 34);
-            this.upJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.upJobStartAtLabel.Location = new System.Drawing.Point(126, 51);
             this.upJobStartAtLabel.Name = "upJobStartAtLabel";
-            this.upJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
+            this.upJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
             this.upJobStartAtLabel.TabIndex = 2;
             this.upJobStartAtLabel.Text = "start at";
             this.upJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -861,11 +809,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.upJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 29);
-            this.upJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 48);
             this.upJobStartAtDateTimePicker.Name = "upJobStartAtDateTimePicker";
             this.upJobStartAtDateTimePicker.ShowUpDown = true;
-            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
+            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
             this.upJobStartAtDateTimePicker.TabIndex = 8;
             this.upJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -873,11 +820,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobMinutesDateTimePicker.CustomFormat = "mm";
             this.upJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 29);
-            this.upJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 48);
             this.upJobMinutesDateTimePicker.Name = "upJobMinutesDateTimePicker";
             this.upJobMinutesDateTimePicker.ShowUpDown = true;
-            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.upJobMinutesDateTimePicker.TabIndex = 7;
             this.upJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -885,11 +831,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobHoursDateTimePicker.CustomFormat = "HH";
             this.upJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 29);
-            this.upJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 48);
             this.upJobHoursDateTimePicker.Name = "upJobHoursDateTimePicker";
             this.upJobHoursDateTimePicker.ShowUpDown = true;
-            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.upJobHoursDateTimePicker.TabIndex = 6;
             this.upJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -901,10 +846,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.cancelButton,
             this.addJobButton,
             this.customActionsButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 851);
+            this.bottomToolStrip.Location = new System.Drawing.Point(0, 551);
             this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Padding = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.bottomToolStrip.Size = new System.Drawing.Size(1076, 32);
+            this.bottomToolStrip.Size = new System.Drawing.Size(721, 25);
             this.bottomToolStrip.TabIndex = 7;
             // 
             // cancelButton
@@ -913,7 +857,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(67, 29);
+            this.cancelButton.Size = new System.Drawing.Size(47, 22);
             this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
             this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
             // 
@@ -923,7 +867,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(146, 29);
+            this.addJobButton.Size = new System.Drawing.Size(97, 22);
             this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
             this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
             // 
@@ -932,7 +876,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.customActionsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.customActionsButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.customActionsButton.Name = "customActionsButton";
-            this.customActionsButton.Size = new System.Drawing.Size(193, 29);
+            this.customActionsButton.Size = new System.Drawing.Size(129, 22);
             this.customActionsButton.Text = "Custom Odata actions";
             this.customActionsButton.Click += new System.EventHandler(this.CustomActionsButton_Click);
             // 
@@ -957,11 +901,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingJobGroupBox.Controls.Add(this.procJobMinutesDateTimePicker);
             this.processingJobGroupBox.Controls.Add(this.procJobHoursDateTimePicker);
             this.processingJobGroupBox.Enabled = false;
-            this.processingJobGroupBox.Location = new System.Drawing.Point(375, 565);
-            this.processingJobGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingJobGroupBox.Location = new System.Drawing.Point(250, 367);
             this.processingJobGroupBox.Name = "processingJobGroupBox";
-            this.processingJobGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.processingJobGroupBox.Size = new System.Drawing.Size(345, 194);
+            this.processingJobGroupBox.Size = new System.Drawing.Size(230, 126);
             this.processingJobGroupBox.TabIndex = 5;
             this.processingJobGroupBox.TabStop = false;
             this.processingJobGroupBox.Text = "Execution monitoring job";
@@ -970,19 +912,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobTriggerTypePanel.Controls.Add(this.procJobCronTriggerRadioButton);
             this.procJobTriggerTypePanel.Controls.Add(this.procJobSimpleTriggerRadioButton);
-            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(14, 74);
-            this.procJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(9, 48);
             this.procJobTriggerTypePanel.Name = "procJobTriggerTypePanel";
-            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
+            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
             this.procJobTriggerTypePanel.TabIndex = 38;
             // 
             // procJobCronTriggerRadioButton
             // 
             this.procJobCronTriggerRadioButton.AutoSize = true;
-            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 2);
-            this.procJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 1);
             this.procJobCronTriggerRadioButton.Name = "procJobCronTriggerRadioButton";
-            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
+            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
             this.procJobCronTriggerRadioButton.TabIndex = 1;
             this.procJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.procJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -992,10 +932,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobSimpleTriggerRadioButton.AutoSize = true;
             this.procJobSimpleTriggerRadioButton.Checked = true;
-            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.procJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
             this.procJobSimpleTriggerRadioButton.Name = "procJobSimpleTriggerRadioButton";
-            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
+            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
             this.procJobSimpleTriggerRadioButton.TabIndex = 0;
             this.procJobSimpleTriggerRadioButton.TabStop = true;
             this.procJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -1004,30 +943,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobCronExpressionLabel
             // 
             this.procJobCronExpressionLabel.AutoSize = true;
-            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(9, 122);
-            this.procJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(6, 79);
             this.procJobCronExpressionLabel.Name = "procJobCronExpressionLabel";
-            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
+            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
             this.procJobCronExpressionLabel.TabIndex = 3;
             this.procJobCronExpressionLabel.Text = "Cron expression";
             // 
             // procJobCronExpressionTextBox
             // 
             this.procJobCronExpressionTextBox.Enabled = false;
-            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 146);
-            this.procJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 95);
             this.procJobCronExpressionTextBox.Name = "procJobCronExpressionTextBox";
-            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
+            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
             this.procJobCronExpressionTextBox.TabIndex = 7;
             this.procJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // procJobMinutesLabel
             // 
             this.procJobMinutesLabel.AutoSize = true;
-            this.procJobMinutesLabel.Location = new System.Drawing.Point(96, 38);
+            this.procJobMinutesLabel.Location = new System.Drawing.Point(64, 25);
             this.procJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobMinutesLabel.Name = "procJobMinutesLabel";
-            this.procJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
+            this.procJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
             this.procJobMinutesLabel.TabIndex = 1;
             this.procJobMinutesLabel.Text = "M:";
             this.procJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1035,10 +972,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobHoursLabel
             // 
             this.procJobHoursLabel.AutoSize = true;
-            this.procJobHoursLabel.Location = new System.Drawing.Point(9, 38);
+            this.procJobHoursLabel.Location = new System.Drawing.Point(6, 25);
             this.procJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobHoursLabel.Name = "procJobHoursLabel";
-            this.procJobHoursLabel.Size = new System.Drawing.Size(25, 20);
+            this.procJobHoursLabel.Size = new System.Drawing.Size(18, 13);
             this.procJobHoursLabel.TabIndex = 0;
             this.procJobHoursLabel.Text = "H:";
             this.procJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1046,10 +983,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobStartAtLabel
             // 
             this.procJobStartAtLabel.AutoSize = true;
-            this.procJobStartAtLabel.Location = new System.Drawing.Point(189, 38);
-            this.procJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.procJobStartAtLabel.Location = new System.Drawing.Point(126, 25);
             this.procJobStartAtLabel.Name = "procJobStartAtLabel";
-            this.procJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
+            this.procJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
             this.procJobStartAtLabel.TabIndex = 2;
             this.procJobStartAtLabel.Text = "start at";
             this.procJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1058,11 +994,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.procJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 34);
-            this.procJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 22);
             this.procJobStartAtDateTimePicker.Name = "procJobStartAtDateTimePicker";
             this.procJobStartAtDateTimePicker.ShowUpDown = true;
-            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
+            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
             this.procJobStartAtDateTimePicker.TabIndex = 6;
             this.procJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -1070,11 +1005,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobMinutesDateTimePicker.CustomFormat = "mm";
             this.procJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 34);
-            this.procJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 22);
             this.procJobMinutesDateTimePicker.Name = "procJobMinutesDateTimePicker";
             this.procJobMinutesDateTimePicker.ShowUpDown = true;
-            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.procJobMinutesDateTimePicker.TabIndex = 5;
             this.procJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 30, 0, 0);
             // 
@@ -1082,21 +1016,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobHoursDateTimePicker.CustomFormat = "HH";
             this.procJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 34);
-            this.procJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 22);
             this.procJobHoursDateTimePicker.Name = "procJobHoursDateTimePicker";
             this.procJobHoursDateTimePicker.ShowUpDown = true;
-            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.procJobHoursDateTimePicker.TabIndex = 4;
             this.procJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
             // useMonitoringJobCheckBox
             // 
             this.useMonitoringJobCheckBox.AutoSize = true;
-            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(374, 535);
-            this.useMonitoringJobCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(249, 348);
             this.useMonitoringJobCheckBox.Name = "useMonitoringJobCheckBox";
-            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(167, 24);
+            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(113, 17);
             this.useMonitoringJobCheckBox.TabIndex = 4;
             this.useMonitoringJobCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_monitoring_job;
             this.useMonitoringJobCheckBox.UseVisualStyleBackColor = true;
@@ -1110,11 +1042,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.fileSelectionGroupBox.Controls.Add(this.orderLabel);
             this.fileSelectionGroupBox.Controls.Add(this.orderByLabel);
             this.fileSelectionGroupBox.Controls.Add(this.searchPatternLabel);
-            this.fileSelectionGroupBox.Location = new System.Drawing.Point(375, 171);
-            this.fileSelectionGroupBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.fileSelectionGroupBox.Location = new System.Drawing.Point(250, 111);
+            this.fileSelectionGroupBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.fileSelectionGroupBox.Name = "fileSelectionGroupBox";
-            this.fileSelectionGroupBox.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            this.fileSelectionGroupBox.Size = new System.Drawing.Size(344, 149);
+            this.fileSelectionGroupBox.Padding = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.fileSelectionGroupBox.Size = new System.Drawing.Size(229, 97);
             this.fileSelectionGroupBox.TabIndex = 2;
             this.fileSelectionGroupBox.TabStop = false;
             this.fileSelectionGroupBox.Text = "Files filter and order";
@@ -1123,29 +1055,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderByComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.orderByComboBox.FormattingEnabled = true;
-            this.orderByComboBox.Location = new System.Drawing.Point(87, 62);
-            this.orderByComboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.orderByComboBox.Location = new System.Drawing.Point(58, 40);
+            this.orderByComboBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.orderByComboBox.Name = "orderByComboBox";
-            this.orderByComboBox.Size = new System.Drawing.Size(250, 28);
+            this.orderByComboBox.Size = new System.Drawing.Size(168, 21);
             this.orderByComboBox.TabIndex = 4;
             // 
             // panel1
             // 
             this.panel1.Controls.Add(this.orderDescendingRadioButton);
             this.panel1.Controls.Add(this.orderAscendingRadioButton);
-            this.panel1.Location = new System.Drawing.Point(64, 102);
+            this.panel1.Location = new System.Drawing.Point(43, 66);
             this.panel1.Margin = new System.Windows.Forms.Padding(0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(272, 35);
+            this.panel1.Size = new System.Drawing.Size(181, 23);
             this.panel1.TabIndex = 4;
             // 
             // orderDescendingRadioButton
             // 
             this.orderDescendingRadioButton.AutoSize = true;
-            this.orderDescendingRadioButton.Location = new System.Drawing.Point(152, 5);
+            this.orderDescendingRadioButton.Location = new System.Drawing.Point(101, 3);
             this.orderDescendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderDescendingRadioButton.Name = "orderDescendingRadioButton";
-            this.orderDescendingRadioButton.Size = new System.Drawing.Size(119, 24);
+            this.orderDescendingRadioButton.Size = new System.Drawing.Size(82, 17);
             this.orderDescendingRadioButton.TabIndex = 1;
             this.orderDescendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Descending;
             this.orderDescendingRadioButton.UseVisualStyleBackColor = true;
@@ -1154,10 +1086,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderAscendingRadioButton.AutoSize = true;
             this.orderAscendingRadioButton.Checked = true;
-            this.orderAscendingRadioButton.Location = new System.Drawing.Point(6, 5);
+            this.orderAscendingRadioButton.Location = new System.Drawing.Point(4, 3);
             this.orderAscendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderAscendingRadioButton.Name = "orderAscendingRadioButton";
-            this.orderAscendingRadioButton.Size = new System.Drawing.Size(109, 24);
+            this.orderAscendingRadioButton.Size = new System.Drawing.Size(75, 17);
             this.orderAscendingRadioButton.TabIndex = 0;
             this.orderAscendingRadioButton.TabStop = true;
             this.orderAscendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Ascending;
@@ -1165,37 +1097,40 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // searchPatternTextBox
             // 
-            this.searchPatternTextBox.Location = new System.Drawing.Point(128, 28);
-            this.searchPatternTextBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.searchPatternTextBox.Location = new System.Drawing.Point(85, 18);
+            this.searchPatternTextBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.searchPatternTextBox.Name = "searchPatternTextBox";
-            this.searchPatternTextBox.Size = new System.Drawing.Size(210, 26);
+            this.searchPatternTextBox.Size = new System.Drawing.Size(141, 20);
             this.searchPatternTextBox.TabIndex = 3;
             this.searchPatternTextBox.Text = "*.zip";
             // 
             // orderLabel
             // 
             this.orderLabel.AutoSize = true;
-            this.orderLabel.Location = new System.Drawing.Point(8, 102);
+            this.orderLabel.Location = new System.Drawing.Point(5, 66);
+            this.orderLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.orderLabel.Name = "orderLabel";
-            this.orderLabel.Size = new System.Drawing.Size(49, 20);
+            this.orderLabel.Size = new System.Drawing.Size(33, 13);
             this.orderLabel.TabIndex = 2;
             this.orderLabel.Text = "Order";
             // 
             // orderByLabel
             // 
             this.orderByLabel.AutoSize = true;
-            this.orderByLabel.Location = new System.Drawing.Point(8, 66);
+            this.orderByLabel.Location = new System.Drawing.Point(5, 43);
+            this.orderByLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.orderByLabel.Name = "orderByLabel";
-            this.orderByLabel.Size = new System.Drawing.Size(69, 20);
+            this.orderByLabel.Size = new System.Drawing.Size(47, 13);
             this.orderByLabel.TabIndex = 1;
             this.orderByLabel.Text = "Order by";
             // 
             // searchPatternLabel
             // 
             this.searchPatternLabel.AutoSize = true;
-            this.searchPatternLabel.Location = new System.Drawing.Point(8, 31);
+            this.searchPatternLabel.Location = new System.Drawing.Point(5, 20);
+            this.searchPatternLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.searchPatternLabel.Name = "searchPatternLabel";
-            this.searchPatternLabel.Size = new System.Drawing.Size(115, 20);
+            this.searchPatternLabel.Size = new System.Drawing.Size(77, 13);
             this.searchPatternLabel.TabIndex = 0;
             this.searchPatternLabel.Text = "Search pattern";
             // 
@@ -1205,11 +1140,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.importDetailsGroupBox.Controls.Add(this.overwriteDataProjectCheckBox);
             this.importDetailsGroupBox.Controls.Add(this.dataProject);
             this.importDetailsGroupBox.Controls.Add(this.dataProjectLabel);
-            this.importDetailsGroupBox.Location = new System.Drawing.Point(374, 29);
-            this.importDetailsGroupBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.importDetailsGroupBox.Location = new System.Drawing.Point(249, 19);
+            this.importDetailsGroupBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.importDetailsGroupBox.Name = "importDetailsGroupBox";
-            this.importDetailsGroupBox.Padding = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            this.importDetailsGroupBox.Size = new System.Drawing.Size(344, 129);
+            this.importDetailsGroupBox.Padding = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.importDetailsGroupBox.Size = new System.Drawing.Size(229, 84);
             this.importDetailsGroupBox.TabIndex = 1;
             this.importDetailsGroupBox.TabStop = false;
             this.importDetailsGroupBox.Text = "Import details";
@@ -1219,10 +1154,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.executeImportCheckBox.AutoSize = true;
             this.executeImportCheckBox.Checked = true;
             this.executeImportCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.executeImportCheckBox.Location = new System.Drawing.Point(10, 100);
-            this.executeImportCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.executeImportCheckBox.Location = new System.Drawing.Point(7, 65);
             this.executeImportCheckBox.Name = "executeImportCheckBox";
-            this.executeImportCheckBox.Size = new System.Drawing.Size(141, 24);
+            this.executeImportCheckBox.Size = new System.Drawing.Size(96, 17);
             this.executeImportCheckBox.TabIndex = 3;
             this.executeImportCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Execute_import;
             this.executeImportCheckBox.UseVisualStyleBackColor = true;
@@ -1232,28 +1166,28 @@ namespace RecurringIntegrationsScheduler.Forms
             this.overwriteDataProjectCheckBox.AutoSize = true;
             this.overwriteDataProjectCheckBox.Checked = true;
             this.overwriteDataProjectCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.overwriteDataProjectCheckBox.Location = new System.Drawing.Point(10, 65);
-            this.overwriteDataProjectCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.overwriteDataProjectCheckBox.Location = new System.Drawing.Point(7, 42);
             this.overwriteDataProjectCheckBox.Name = "overwriteDataProjectCheckBox";
-            this.overwriteDataProjectCheckBox.Size = new System.Drawing.Size(257, 24);
+            this.overwriteDataProjectCheckBox.Size = new System.Drawing.Size(175, 17);
             this.overwriteDataProjectCheckBox.TabIndex = 2;
             this.overwriteDataProjectCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Overwrite_data_project_definition;
             this.overwriteDataProjectCheckBox.UseVisualStyleBackColor = true;
             // 
             // dataProject
             // 
-            this.dataProject.Location = new System.Drawing.Point(128, 28);
-            this.dataProject.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.dataProject.Location = new System.Drawing.Point(85, 18);
+            this.dataProject.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.dataProject.Name = "dataProject";
-            this.dataProject.Size = new System.Drawing.Size(210, 26);
+            this.dataProject.Size = new System.Drawing.Size(141, 20);
             this.dataProject.TabIndex = 1;
             // 
             // dataProjectLabel
             // 
             this.dataProjectLabel.AutoSize = true;
-            this.dataProjectLabel.Location = new System.Drawing.Point(8, 31);
+            this.dataProjectLabel.Location = new System.Drawing.Point(5, 20);
+            this.dataProjectLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.dataProjectLabel.Name = "dataProjectLabel";
-            this.dataProjectLabel.Size = new System.Drawing.Size(96, 20);
+            this.dataProjectLabel.Size = new System.Drawing.Size(65, 13);
             this.dataProjectLabel.TabIndex = 0;
             this.dataProjectLabel.Text = "Data project";
             // 
@@ -1267,26 +1201,23 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(729, 660);
-            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(486, 478);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 103);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 67);
             this.retryPolicyGroupBox.TabIndex = 8;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(148, 65);
-            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(99, 42);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesDelayUpDown.TabIndex = 10;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -1297,24 +1228,22 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 68);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(7, 44);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(123, 20);
+            this.label2.Size = new System.Drawing.Size(83, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(148, 28);
-            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(99, 18);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesCountUpDown.TabIndex = 9;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -1325,19 +1254,20 @@ namespace RecurringIntegrationsScheduler.Forms
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(10, 31);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(7, 20);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(131, 20);
+            this.label1.Size = new System.Drawing.Size(87, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(729, 770);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(250, 498);
+            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 113);
+            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 51);
             this.groupBoxExceptions.TabIndex = 9;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -1347,19 +1277,31 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(14, 26);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
+            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
+            // pauseIndefinitelyCheckBox
+            // 
+            this.pauseIndefinitelyCheckBox.AutoSize = true;
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(10, 19);
+            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
+            this.pauseIndefinitelyCheckBox.TabIndex = 0;
+            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
+            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            // 
             // ImportJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(1076, 883);
+            this.ClientSize = new System.Drawing.Size(721, 576);
             this.Controls.Add(this.bottomToolStrip);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.importDetailsGroupBox);
@@ -1371,10 +1313,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.Controls.Add(this.useMonitoringJobCheckBox);
             this.Controls.Add(this.retryPolicyGroupBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(1098, 925);
+            this.MinimumSize = new System.Drawing.Size(737, 615);
             this.Name = "ImportJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -1520,5 +1461,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
         private System.Windows.Forms.ToolStripButton customActionsButton;
+        private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
     }
 }

--- a/Scheduler/Forms/ImportJob.cs
+++ b/Scheduler/Forms/ImportJob.cs
@@ -228,8 +228,8 @@ namespace RecurringIntegrationsScheduler.Forms
                                                              .ToString());
 
                 pauseIndefinitelyCheckBox.Checked =
-                    (UploadJobDetail.JobDataMap[SettingsConstants.IndefinitePause] != null) &&
-                    Convert.ToBoolean(UploadJobDetail.JobDataMap[SettingsConstants.IndefinitePause].ToString());
+                    (ImportJobDetail.JobDataMap[SettingsConstants.IndefinitePause] != null) &&
+                    Convert.ToBoolean(ImportJobDetail.JobDataMap[SettingsConstants.IndefinitePause].ToString());
 
                 if (ImportTrigger.GetType() == typeof(SimpleTriggerImpl))
                 {

--- a/Scheduler/Forms/ImportJob.cs
+++ b/Scheduler/Forms/ImportJob.cs
@@ -227,6 +227,10 @@ namespace RecurringIntegrationsScheduler.Forms
                                                          ImportJobDetail.JobDataMap[SettingsConstants.ReverseOrder]
                                                              .ToString());
 
+                pauseIndefinitelyCheckBox.Checked =
+                    (UploadJobDetail.JobDataMap[SettingsConstants.IndefinitePause] != null) &&
+                    Convert.ToBoolean(UploadJobDetail.JobDataMap[SettingsConstants.IndefinitePause].ToString());
+
                 if (ImportTrigger.GetType() == typeof(SimpleTriggerImpl))
                 {
                     var localTrigger = (SimpleTriggerImpl) ImportTrigger;
@@ -585,7 +589,8 @@ namespace RecurringIntegrationsScheduler.Forms
                 {SettingsConstants.RetryDelay, retriesDelayUpDown.Value.ToString(CultureInfo.InvariantCulture)},
                 {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()},
                 {SettingsConstants.GetAzureWriteUrlActionPath, getAzureWriteUrlPath},
-                {SettingsConstants.ImportFromPackageActionPath, importFromPackagePath}
+                {SettingsConstants.ImportFromPackageActionPath, importFromPackagePath},
+                {SettingsConstants.IndefinitePause, pauseIndefinitelyCheckBox.Checked.ToString()}
             };
             if (serviceAuthRadioButton.Checked)
             {
@@ -620,7 +625,8 @@ namespace RecurringIntegrationsScheduler.Forms
                 {SettingsConstants.RetryDelay, retriesDelayUpDown.Value.ToString(CultureInfo.InvariantCulture)},
                 {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()},
                 {SettingsConstants.GetExecutionSummaryStatusActionPath, getExecutionSummaryStatusPath},
-                {SettingsConstants.GetExecutionSummaryPageUrlActionPath, getExecutionSummaryPageUrlPath}
+                {SettingsConstants.GetExecutionSummaryPageUrlActionPath, getExecutionSummaryPageUrlPath},
+                {SettingsConstants.IndefinitePause, pauseIndefinitelyCheckBox.Checked.ToString()}
             };
             if (serviceAuthRadioButton.Checked)
             {

--- a/Scheduler/Forms/ImportJob.cs
+++ b/Scheduler/Forms/ImportJob.cs
@@ -378,30 +378,6 @@ namespace RecurringIntegrationsScheduler.Forms
             getCronScheduleForUploadButton.Enabled = upJobCronTriggerRadioButton.Checked;
         }
 
-        private void AddJobButton_Click(object sender, EventArgs e)
-        {
-            if (ImportJobDetail == null)
-            {
-                var jobKey = new JobKey(jobName.Text, jobGroupComboBox.Text);
-                if (Scheduler.Instance.GetScheduler().CheckExists(jobKey).Result)
-                    if (
-                        MessageBox.Show(
-                            string.Format(Resources.Job_0_in_group_1_already_exists, jobKey.Name, jobKey.Group),
-                            Resources.Job_already_exists, MessageBoxButtons.YesNo) == DialogResult.No)
-                        return;
-            }
-
-            if (!ValidateJobSettings()) return;
-            ImportJobDetail = GetImportJobDetail();
-            ImportTrigger = GetImportTrigger(ImportJobDetail);
-            if (useMonitoringJobCheckBox.Checked)
-            {
-                ExecutionJobDetail = GetMonitorJobDetail();
-                ExecutionTrigger = GetExecutionTrigger(ExecutionJobDetail);
-            }
-            Close();
-        }
-
         private bool ValidateJobSettings()
         {
             if (upJobCronTriggerRadioButton.Checked)
@@ -714,12 +690,6 @@ namespace RecurringIntegrationsScheduler.Forms
             form.ShowDialog();
         }
 
-        private void CancelButton_Click(object sender, EventArgs e)
-        {
-            Cancelled = true;
-            Close();
-        }
-
         private void UseMonitoringJobCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             processingJobGroupBox.Enabled = useMonitoringJobCheckBox.Checked;
@@ -843,6 +813,36 @@ namespace RecurringIntegrationsScheduler.Forms
             {
                 MessageBox.Show(ex.Message, Resources.Unexpected_error);
             }
+        }
+
+        private void AddJobButton_Click(object sender, EventArgs e)
+        {
+            if (ImportJobDetail == null)
+            {
+                var jobKey = new JobKey(jobName.Text, jobGroupComboBox.Text);
+                if (Scheduler.Instance.GetScheduler().CheckExists(jobKey).Result)
+                    if (
+                        MessageBox.Show(
+                            string.Format(Resources.Job_0_in_group_1_already_exists, jobKey.Name, jobKey.Group),
+                            Resources.Job_already_exists, MessageBoxButtons.YesNo) == DialogResult.No)
+                        return;
+            }
+
+            if (!ValidateJobSettings()) return;
+            ImportJobDetail = GetImportJobDetail();
+            ImportTrigger = GetImportTrigger(ImportJobDetail);
+            if (useMonitoringJobCheckBox.Checked)
+            {
+                ExecutionJobDetail = GetMonitorJobDetail();
+                ExecutionTrigger = GetExecutionTrigger(ExecutionJobDetail);
+            }
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, EventArgs e)
+        {
+            Cancelled = true;
+            Close();
         }
     }
 }

--- a/Scheduler/Forms/ImportJob.resx
+++ b/Scheduler/Forms/ImportJob.resx
@@ -125,9 +125,6 @@
 
 Default example above means: Each working day of the week (MON-FRI) run every 15 minutes (0/15) between 8:00 and 18:45 (8-18 - last run will be at 18:45)</value>
   </data>
-  <metadata name="bottomToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>245, 17</value>
-  </metadata>
   <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>442, 17</value>
   </metadata>

--- a/Scheduler/Forms/UploadJob.Designer.cs
+++ b/Scheduler/Forms/UploadJob.Designer.cs
@@ -76,6 +76,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.instanceLabel = new System.Windows.Forms.Label();
             this.instanceComboBox = new System.Windows.Forms.ComboBox();
             this.recurrenceGroupBox = new System.Windows.Forms.GroupBox();
+            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
             this.getCronScheduleForProcButton = new System.Windows.Forms.Button();
             this.moreExamplesButton = new System.Windows.Forms.Button();
             this.calculatedRunsTextBox = new System.Windows.Forms.TextBox();
@@ -95,9 +96,6 @@ namespace RecurringIntegrationsScheduler.Forms
             this.upJobStartAtDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.upJobMinutesDateTimePicker = new System.Windows.Forms.DateTimePicker();
             this.upJobHoursDateTimePicker = new System.Windows.Forms.DateTimePicker();
-            this.bottomToolStrip = new System.Windows.Forms.ToolStrip();
-            this.cancelButton = new System.Windows.Forms.ToolStripButton();
-            this.addJobButton = new System.Windows.Forms.ToolStripButton();
             this.downloadFolderLabel = new System.Windows.Forms.Label();
             this.processingJobGroupBox = new System.Windows.Forms.GroupBox();
             this.procJobTriggerTypePanel = new System.Windows.Forms.Panel();
@@ -128,13 +126,14 @@ namespace RecurringIntegrationsScheduler.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.groupBoxExceptions = new System.Windows.Forms.GroupBox();
             this.pauseOnExceptionsCheckBox = new System.Windows.Forms.CheckBox();
-            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
+            this.groupBoxButtons = new System.Windows.Forms.GroupBox();
+            this.addJobButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
             this.jobDetailsGroupBox.SuspendLayout();
             this.axDetailsGroupBox.SuspendLayout();
             this.authMethodPanel.SuspendLayout();
             this.recurrenceGroupBox.SuspendLayout();
             this.upJobTriggerTypePanel.SuspendLayout();
-            this.bottomToolStrip.SuspendLayout();
             this.processingJobGroupBox.SuspendLayout();
             this.procJobTriggerTypePanel.SuspendLayout();
             this.fileSelectionGroupBox.SuspendLayout();
@@ -143,6 +142,7 @@ namespace RecurringIntegrationsScheduler.Forms
             ((System.ComponentModel.ISupportInitialize)(this.retriesDelayUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).BeginInit();
             this.groupBoxExceptions.SuspendLayout();
+            this.groupBoxButtons.SuspendLayout();
             this.SuspendLayout();
             // 
             // jobDetailsGroupBox
@@ -177,9 +177,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
+            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(229, 480);
+            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(344, 738);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -189,10 +191,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingErrorsFolderBrowserButton.Enabled = false;
             this.processingErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 368);
+            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 566);
             this.processingErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingErrorsFolderBrowserButton.Name = "processingErrorsFolderBrowserButton";
-            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.processingErrorsFolderBrowserButton.TabIndex = 27;
             this.processingErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -201,26 +203,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingErrorsFolderTextBox
             // 
             this.processingErrorsFolderTextBox.Enabled = false;
-            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(11, 372);
+            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(16, 572);
+            this.processingErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.processingErrorsFolderTextBox.Name = "processingErrorsFolderTextBox";
-            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.processingErrorsFolderTextBox.TabIndex = 26;
             // 
             // processingErrorsFolderLabel
             // 
             this.processingErrorsFolderLabel.AutoSize = true;
-            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(8, 354);
+            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(12, 545);
+            this.processingErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.processingErrorsFolderLabel.Name = "processingErrorsFolderLabel";
-            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(117, 13);
+            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(176, 20);
             this.processingErrorsFolderLabel.TabIndex = 28;
             this.processingErrorsFolderLabel.Text = "Processing errors folder";
             // 
             // statusFileExtensionTextBox
             // 
             this.statusFileExtensionTextBox.Enabled = false;
-            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(142, 454);
+            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(213, 698);
+            this.statusFileExtensionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.statusFileExtensionTextBox.Name = "statusFileExtensionTextBox";
-            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(80, 20);
+            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(118, 26);
             this.statusFileExtensionTextBox.TabIndex = 25;
             this.statusFileExtensionTextBox.Text = ".Status";
             this.statusFileExtensionTextBox.Leave += new System.EventHandler(this.StatusFileExtensionTextBox_Leave);
@@ -228,9 +233,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // statusFileExtensionLabel
             // 
             this.statusFileExtensionLabel.AutoSize = true;
-            this.statusFileExtensionLabel.Location = new System.Drawing.Point(36, 457);
+            this.statusFileExtensionLabel.Location = new System.Drawing.Point(54, 703);
+            this.statusFileExtensionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.statusFileExtensionLabel.Name = "statusFileExtensionLabel";
-            this.statusFileExtensionLabel.Size = new System.Drawing.Size(101, 13);
+            this.statusFileExtensionLabel.Size = new System.Drawing.Size(152, 20);
             this.statusFileExtensionLabel.TabIndex = 24;
             this.statusFileExtensionLabel.Text = "Status file extension";
             // 
@@ -238,26 +244,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.dataPackageCheckBox.AutoSize = true;
             this.dataPackageCheckBox.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.dataPackageCheckBox.Location = new System.Drawing.Point(12, 406);
+            this.dataPackageCheckBox.Location = new System.Drawing.Point(18, 625);
+            this.dataPackageCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.dataPackageCheckBox.Name = "dataPackageCheckBox";
-            this.dataPackageCheckBox.Size = new System.Drawing.Size(148, 17);
+            this.dataPackageCheckBox.Size = new System.Drawing.Size(216, 24);
             this.dataPackageCheckBox.TabIndex = 23;
             this.dataPackageCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Uploading_data_packages;
             this.dataPackageCheckBox.UseVisualStyleBackColor = true;
             // 
             // legalEntityTextBox
             // 
-            this.legalEntityTextBox.Location = new System.Drawing.Point(142, 430);
+            this.legalEntityTextBox.Location = new System.Drawing.Point(213, 662);
+            this.legalEntityTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.legalEntityTextBox.Name = "legalEntityTextBox";
-            this.legalEntityTextBox.Size = new System.Drawing.Size(80, 20);
+            this.legalEntityTextBox.Size = new System.Drawing.Size(118, 26);
             this.legalEntityTextBox.TabIndex = 22;
             // 
             // LegalEntityLabel
             // 
             this.LegalEntityLabel.AutoSize = true;
-            this.LegalEntityLabel.Location = new System.Drawing.Point(28, 432);
+            this.LegalEntityLabel.Location = new System.Drawing.Point(42, 665);
+            this.LegalEntityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LegalEntityLabel.Name = "LegalEntityLabel";
-            this.LegalEntityLabel.Size = new System.Drawing.Size(107, 13);
+            this.LegalEntityLabel.Size = new System.Drawing.Size(160, 20);
             this.LegalEntityLabel.TabIndex = 21;
             this.LegalEntityLabel.Text = "Legal entity (optional)";
             // 
@@ -266,10 +275,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.inputFolderBrowserButton.Enabled = false;
             this.inputFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.inputFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.inputFolderBrowserButton.Location = new System.Drawing.Point(200, 209);
+            this.inputFolderBrowserButton.Location = new System.Drawing.Point(300, 322);
             this.inputFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.inputFolderBrowserButton.Name = "inputFolderBrowserButton";
-            this.inputFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.inputFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.inputFolderBrowserButton.TabIndex = 19;
             this.inputFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.inputFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -278,17 +287,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // inputFolderTextBox
             // 
             this.inputFolderTextBox.Enabled = false;
-            this.inputFolderTextBox.Location = new System.Drawing.Point(11, 213);
+            this.inputFolderTextBox.Location = new System.Drawing.Point(16, 328);
+            this.inputFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.inputFolderTextBox.Name = "inputFolderTextBox";
-            this.inputFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.inputFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.inputFolderTextBox.TabIndex = 18;
             // 
             // inputFolderLabel
             // 
             this.inputFolderLabel.AutoSize = true;
-            this.inputFolderLabel.Location = new System.Drawing.Point(8, 195);
+            this.inputFolderLabel.Location = new System.Drawing.Point(12, 300);
+            this.inputFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.inputFolderLabel.Name = "inputFolderLabel";
-            this.inputFolderLabel.Size = new System.Drawing.Size(77, 13);
+            this.inputFolderLabel.Size = new System.Drawing.Size(116, 20);
             this.inputFolderLabel.TabIndex = 20;
             this.inputFolderLabel.Text = "Input subfolder";
             // 
@@ -297,10 +308,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingSuccessFolderBrowserButton.Enabled = false;
             this.processingSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 328);
+            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 505);
             this.processingSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingSuccessFolderBrowserButton.Name = "processingSuccessFolderBrowserButton";
-            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.processingSuccessFolderBrowserButton.TabIndex = 16;
             this.processingSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -309,17 +320,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingSuccessFolderTextBox
             // 
             this.processingSuccessFolderTextBox.Enabled = false;
-            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(11, 332);
+            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(16, 511);
+            this.processingSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.processingSuccessFolderTextBox.Name = "processingSuccessFolderTextBox";
-            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.processingSuccessFolderTextBox.TabIndex = 15;
             // 
             // processingSuccessFolderLabel
             // 
             this.processingSuccessFolderLabel.AutoSize = true;
-            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(8, 314);
+            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(12, 483);
+            this.processingSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.processingSuccessFolderLabel.Name = "processingSuccessFolderLabel";
-            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(130, 13);
+            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(193, 20);
             this.processingSuccessFolderLabel.TabIndex = 17;
             this.processingSuccessFolderLabel.Text = "Processing success folder";
             // 
@@ -328,10 +341,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadSuccessFolderBrowserButton.Enabled = false;
             this.uploadSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 249);
+            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 383);
             this.uploadSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadSuccessFolderBrowserButton.Name = "uploadSuccessFolderBrowserButton";
-            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.uploadSuccessFolderBrowserButton.TabIndex = 13;
             this.uploadSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -340,17 +353,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadSuccessFolderTextBox
             // 
             this.uploadSuccessFolderTextBox.Enabled = false;
-            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(11, 253);
+            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(16, 389);
+            this.uploadSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.uploadSuccessFolderTextBox.Name = "uploadSuccessFolderTextBox";
-            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.uploadSuccessFolderTextBox.TabIndex = 12;
             // 
             // uploadSuccessFolderLabel
             // 
             this.uploadSuccessFolderLabel.AutoSize = true;
-            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(8, 235);
+            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(12, 362);
+            this.uploadSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uploadSuccessFolderLabel.Name = "uploadSuccessFolderLabel";
-            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(112, 13);
+            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(166, 20);
             this.uploadSuccessFolderLabel.TabIndex = 14;
             this.uploadSuccessFolderLabel.Text = "Upload success folder";
             // 
@@ -359,9 +374,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(10, 174);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(15, 268);
+            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(165, 17);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(247, 24);
             this.useStandardSubfolder.TabIndex = 8;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_subfolders_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -372,10 +388,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadErrorsFolderBrowserButton.Enabled = false;
             this.uploadErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 288);
+            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 443);
             this.uploadErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadErrorsFolderBrowserButton.Name = "uploadErrorsFolderBrowserButton";
-            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.uploadErrorsFolderBrowserButton.TabIndex = 7;
             this.uploadErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -384,17 +400,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadErrorsFolderTextBox
             // 
             this.uploadErrorsFolderTextBox.Enabled = false;
-            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(11, 292);
+            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(16, 449);
+            this.uploadErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.uploadErrorsFolderTextBox.Name = "uploadErrorsFolderTextBox";
-            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.uploadErrorsFolderTextBox.TabIndex = 6;
             // 
             // uploadErrorsFolderLabel
             // 
             this.uploadErrorsFolderLabel.AutoSize = true;
-            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(8, 275);
+            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(12, 423);
+            this.uploadErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.uploadErrorsFolderLabel.Name = "uploadErrorsFolderLabel";
-            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(99, 13);
+            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(149, 20);
             this.uploadErrorsFolderLabel.TabIndex = 11;
             this.uploadErrorsFolderLabel.Text = "Upload errors folder";
             // 
@@ -402,10 +420,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.topUploadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.topUploadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(200, 148);
+            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(300, 228);
             this.topUploadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.topUploadFolderBrowserButton.Name = "topUploadFolderBrowserButton";
-            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
+            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
             this.topUploadFolderBrowserButton.TabIndex = 5;
             this.topUploadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.topUploadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -413,35 +431,39 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // topUploadFolderTextBox
             // 
-            this.topUploadFolderTextBox.Location = new System.Drawing.Point(11, 152);
+            this.topUploadFolderTextBox.Location = new System.Drawing.Point(16, 234);
+            this.topUploadFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.topUploadFolderTextBox.Name = "topUploadFolderTextBox";
-            this.topUploadFolderTextBox.Size = new System.Drawing.Size(187, 20);
+            this.topUploadFolderTextBox.Size = new System.Drawing.Size(278, 26);
             this.topUploadFolderTextBox.TabIndex = 4;
             this.topUploadFolderTextBox.TextChanged += new System.EventHandler(this.TopUploadFolder_TextChanged);
             // 
             // topUploadFolderLabel
             // 
             this.topUploadFolderLabel.AutoSize = true;
-            this.topUploadFolderLabel.Location = new System.Drawing.Point(8, 134);
+            this.topUploadFolderLabel.Location = new System.Drawing.Point(12, 206);
+            this.topUploadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.topUploadFolderLabel.Name = "topUploadFolderLabel";
-            this.topUploadFolderLabel.Size = new System.Drawing.Size(90, 13);
+            this.topUploadFolderLabel.Size = new System.Drawing.Size(132, 20);
             this.topUploadFolderLabel.TabIndex = 8;
             this.topUploadFolderLabel.Text = "Top upload folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(12, 94);
+            this.jobDescription.Location = new System.Drawing.Point(18, 145);
+            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(211, 36);
+            this.jobDescription.Size = new System.Drawing.Size(314, 53);
             this.jobDescription.TabIndex = 3;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(8, 76);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(12, 117);
+            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
             this.jobDescriptionLabel.TabIndex = 4;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -449,34 +471,38 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
+            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 2;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(8, 52);
+            this.jobGroupLabel.Location = new System.Drawing.Point(12, 80);
+            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
+            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
             this.jobGroupLabel.TabIndex = 2;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(50, 17);
+            this.jobName.Location = new System.Drawing.Point(75, 26);
+            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(173, 20);
+            this.jobName.Size = new System.Drawing.Size(258, 26);
             this.jobName.TabIndex = 1;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(8, 20);
+            this.jobNameLabel.Location = new System.Drawing.Point(12, 31);
+            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
+            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -491,9 +517,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(250, 115);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(375, 177);
+            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 161);
+            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 248);
             this.axDetailsGroupBox.TabIndex = 1;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -501,9 +529,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(12, 105);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(18, 162);
+            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
             this.aadApplicationLabel.TabIndex = 32;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -511,26 +540,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(106, 102);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(159, 157);
+            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(117, 21);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(174, 28);
             this.aadApplicationComboBox.TabIndex = 31;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(8, 71);
+            this.authMethodPanel.Location = new System.Drawing.Point(12, 109);
+            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(214, 25);
+            this.authMethodPanel.Size = new System.Drawing.Size(321, 38);
             this.authMethodPanel.TabIndex = 30;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
+            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
             this.serviceAuthRadioButton.TabIndex = 16;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -540,9 +572,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
             this.userAuthRadioButton.TabIndex = 15;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -551,9 +584,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // dataJobLabel
             // 
             this.dataJobLabel.AutoSize = true;
-            this.dataJobLabel.Location = new System.Drawing.Point(20, 47);
+            this.dataJobLabel.Location = new System.Drawing.Point(30, 72);
+            this.dataJobLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.dataJobLabel.Name = "dataJobLabel";
-            this.dataJobLabel.Size = new System.Drawing.Size(47, 13);
+            this.dataJobLabel.Size = new System.Drawing.Size(69, 20);
             this.dataJobLabel.TabIndex = 22;
             this.dataJobLabel.Text = "Data job";
             // 
@@ -561,17 +595,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.dataJobComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.dataJobComboBox.FormattingEnabled = true;
-            this.dataJobComboBox.Location = new System.Drawing.Point(76, 45);
+            this.dataJobComboBox.Location = new System.Drawing.Point(114, 69);
+            this.dataJobComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.dataJobComboBox.Name = "dataJobComboBox";
-            this.dataJobComboBox.Size = new System.Drawing.Size(147, 21);
+            this.dataJobComboBox.Size = new System.Drawing.Size(218, 28);
             this.dataJobComboBox.TabIndex = 11;
             // 
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(68, 131);
+            this.userLabel.Location = new System.Drawing.Point(102, 202);
+            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(29, 13);
+            this.userLabel.Size = new System.Drawing.Size(43, 20);
             this.userLabel.TabIndex = 19;
             this.userLabel.Text = "User";
             // 
@@ -579,17 +615,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(106, 128);
+            this.userComboBox.Location = new System.Drawing.Point(159, 197);
+            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(117, 21);
+            this.userComboBox.Size = new System.Drawing.Size(174, 28);
             this.userComboBox.TabIndex = 10;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(20, 22);
+            this.instanceLabel.Location = new System.Drawing.Point(30, 34);
+            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
+            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
             this.instanceLabel.TabIndex = 16;
             this.instanceLabel.Text = "Instance";
             // 
@@ -597,9 +635,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(76, 19);
+            this.instanceComboBox.Location = new System.Drawing.Point(114, 29);
+            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
+            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
             this.instanceComboBox.TabIndex = 9;
             // 
             // recurrenceGroupBox
@@ -622,19 +661,32 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.upJobStartAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobMinutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobHoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(486, 13);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(729, 20);
+            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 450);
+            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 692);
             this.recurrenceGroupBox.TabIndex = 2;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
             // 
+            // pauseIndefinitelyCheckBox
+            // 
+            this.pauseIndefinitelyCheckBox.AutoSize = true;
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(14, 26);
+            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(183, 24);
+            this.pauseIndefinitelyCheckBox.TabIndex = 0;
+            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
+            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            // 
             // getCronScheduleForProcButton
             // 
             this.getCronScheduleForProcButton.Enabled = false;
-            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(119, 336);
+            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(178, 517);
+            this.getCronScheduleForProcButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.getCronScheduleForProcButton.Name = "getCronScheduleForProcButton";
-            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(105, 36);
+            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(158, 55);
             this.getCronScheduleForProcButton.TabIndex = 33;
             this.getCronScheduleForProcButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Get_cron_schedule_for_monitor_job;
             this.getCronScheduleForProcButton.UseVisualStyleBackColor = true;
@@ -642,9 +694,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(158, 376);
+            this.moreExamplesButton.Location = new System.Drawing.Point(237, 578);
+            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(66, 55);
+            this.moreExamplesButton.Size = new System.Drawing.Size(99, 85);
             this.moreExamplesButton.TabIndex = 19;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -653,20 +706,22 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 376);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(14, 578);
+            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 55);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 82);
             this.calculatedRunsTextBox.TabIndex = 32;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // getCronScheduleForUploadButton
             // 
             this.getCronScheduleForUploadButton.Enabled = false;
-            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(9, 336);
+            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(14, 517);
+            this.getCronScheduleForUploadButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.getCronScheduleForUploadButton.Name = "getCronScheduleForUploadButton";
-            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(105, 36);
+            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(158, 55);
             this.getCronScheduleForUploadButton.TabIndex = 18;
             this.getCronScheduleForUploadButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Get_cron_schedule_for_upload_job;
             this.getCronScheduleForUploadButton.UseVisualStyleBackColor = true;
@@ -675,9 +730,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 317);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 488);
+            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
             this.cronDocsLinkLabel.TabIndex = 30;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -687,17 +743,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobTriggerTypePanel.Controls.Add(this.upJobCronTriggerRadioButton);
             this.upJobTriggerTypePanel.Controls.Add(this.upJobSimpleTriggerRadioButton);
-            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(9, 74);
+            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(14, 114);
+            this.upJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobTriggerTypePanel.Name = "upJobTriggerTypePanel";
-            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
+            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
             this.upJobTriggerTypePanel.TabIndex = 29;
             // 
             // upJobCronTriggerRadioButton
             // 
             this.upJobCronTriggerRadioButton.AutoSize = true;
-            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 3);
+            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 5);
+            this.upJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobCronTriggerRadioButton.Name = "upJobCronTriggerRadioButton";
-            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
+            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
             this.upJobCronTriggerRadioButton.TabIndex = 16;
             this.upJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.upJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -707,9 +765,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobSimpleTriggerRadioButton.AutoSize = true;
             this.upJobSimpleTriggerRadioButton.Checked = true;
-            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.upJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobSimpleTriggerRadioButton.Name = "upJobSimpleTriggerRadioButton";
-            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
+            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
             this.upJobSimpleTriggerRadioButton.TabIndex = 15;
             this.upJobSimpleTriggerRadioButton.TabStop = true;
             this.upJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -718,9 +777,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(6, 297);
+            this.buildCronLabel.Location = new System.Drawing.Point(9, 457);
+            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
+            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
             this.buildCronLabel.TabIndex = 26;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -728,10 +788,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 147);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 226);
+            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(215, 147);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(322, 226);
             this.cronTriggerInfoTextBox.TabIndex = 25;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -739,9 +800,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(126, 297);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(189, 457);
+            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
             this.cronmakerLinkLabel.TabIndex = 24;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -750,28 +812,30 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobCronExpressionLabel
             // 
             this.upJobCronExpressionLabel.AutoSize = true;
-            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(6, 105);
+            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(9, 162);
+            this.upJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.upJobCronExpressionLabel.Name = "upJobCronExpressionLabel";
-            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
+            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
             this.upJobCronExpressionLabel.TabIndex = 23;
             this.upJobCronExpressionLabel.Text = "Cron expression";
             // 
             // upJobCronExpressionTextBox
             // 
             this.upJobCronExpressionTextBox.Enabled = false;
-            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 121);
+            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 186);
+            this.upJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobCronExpressionTextBox.Name = "upJobCronExpressionTextBox";
-            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
+            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
             this.upJobCronExpressionTextBox.TabIndex = 17;
             this.upJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // upJobMinutesLabel
             // 
             this.upJobMinutesLabel.AutoSize = true;
-            this.upJobMinutesLabel.Location = new System.Drawing.Point(64, 51);
+            this.upJobMinutesLabel.Location = new System.Drawing.Point(96, 78);
             this.upJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobMinutesLabel.Name = "upJobMinutesLabel";
-            this.upJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
+            this.upJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
             this.upJobMinutesLabel.TabIndex = 5;
             this.upJobMinutesLabel.Text = "M:";
             this.upJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -779,10 +843,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobHoursLabel
             // 
             this.upJobHoursLabel.AutoSize = true;
-            this.upJobHoursLabel.Location = new System.Drawing.Point(6, 51);
+            this.upJobHoursLabel.Location = new System.Drawing.Point(9, 78);
             this.upJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobHoursLabel.Name = "upJobHoursLabel";
-            this.upJobHoursLabel.Size = new System.Drawing.Size(18, 13);
+            this.upJobHoursLabel.Size = new System.Drawing.Size(25, 20);
             this.upJobHoursLabel.TabIndex = 4;
             this.upJobHoursLabel.Text = "H:";
             this.upJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -790,9 +854,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobStartAtLabel
             // 
             this.upJobStartAtLabel.AutoSize = true;
-            this.upJobStartAtLabel.Location = new System.Drawing.Point(126, 51);
+            this.upJobStartAtLabel.Location = new System.Drawing.Point(189, 78);
+            this.upJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.upJobStartAtLabel.Name = "upJobStartAtLabel";
-            this.upJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
+            this.upJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
             this.upJobStartAtLabel.TabIndex = 3;
             this.upJobStartAtLabel.Text = "start at";
             this.upJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -801,10 +866,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.upJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 48);
+            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 74);
+            this.upJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobStartAtDateTimePicker.Name = "upJobStartAtDateTimePicker";
             this.upJobStartAtDateTimePicker.ShowUpDown = true;
-            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
+            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
             this.upJobStartAtDateTimePicker.TabIndex = 14;
             this.upJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -812,10 +878,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobMinutesDateTimePicker.CustomFormat = "mm";
             this.upJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 48);
+            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 74);
+            this.upJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobMinutesDateTimePicker.Name = "upJobMinutesDateTimePicker";
             this.upJobMinutesDateTimePicker.ShowUpDown = true;
-            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.upJobMinutesDateTimePicker.TabIndex = 13;
             this.upJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -823,45 +890,13 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobHoursDateTimePicker.CustomFormat = "HH";
             this.upJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 48);
+            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 74);
+            this.upJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.upJobHoursDateTimePicker.Name = "upJobHoursDateTimePicker";
             this.upJobHoursDateTimePicker.ShowUpDown = true;
-            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.upJobHoursDateTimePicker.TabIndex = 12;
             this.upJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
-            // 
-            // bottomToolStrip
-            // 
-            this.bottomToolStrip.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.bottomToolStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.bottomToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cancelButton,
-            this.addJobButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 515);
-            this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Size = new System.Drawing.Size(723, 25);
-            this.bottomToolStrip.TabIndex = 3;
-            this.bottomToolStrip.Text = "toolStrip1";
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(47, 22);
-            this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
-            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
-            // 
-            // addJobButton
-            // 
-            this.addJobButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(97, 22);
-            this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
-            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
             // 
             // downloadFolderLabel
             // 
@@ -884,9 +919,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingJobGroupBox.Controls.Add(this.procJobMinutesDateTimePicker);
             this.processingJobGroupBox.Controls.Add(this.procJobHoursDateTimePicker);
             this.processingJobGroupBox.Enabled = false;
-            this.processingJobGroupBox.Location = new System.Drawing.Point(250, 303);
+            this.processingJobGroupBox.Location = new System.Drawing.Point(375, 466);
+            this.processingJobGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.processingJobGroupBox.Name = "processingJobGroupBox";
-            this.processingJobGroupBox.Size = new System.Drawing.Size(230, 126);
+            this.processingJobGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingJobGroupBox.Size = new System.Drawing.Size(345, 194);
             this.processingJobGroupBox.TabIndex = 4;
             this.processingJobGroupBox.TabStop = false;
             this.processingJobGroupBox.Text = "Processing monitor job";
@@ -895,17 +932,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobTriggerTypePanel.Controls.Add(this.procJobCronTriggerRadioButton);
             this.procJobTriggerTypePanel.Controls.Add(this.procJobSimpleTriggerRadioButton);
-            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(9, 48);
+            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(14, 74);
+            this.procJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobTriggerTypePanel.Name = "procJobTriggerTypePanel";
-            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
+            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
             this.procJobTriggerTypePanel.TabIndex = 38;
             // 
             // procJobCronTriggerRadioButton
             // 
             this.procJobCronTriggerRadioButton.AutoSize = true;
-            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 2);
+            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 3);
+            this.procJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobCronTriggerRadioButton.Name = "procJobCronTriggerRadioButton";
-            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
+            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
             this.procJobCronTriggerRadioButton.TabIndex = 16;
             this.procJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.procJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -915,9 +954,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobSimpleTriggerRadioButton.AutoSize = true;
             this.procJobSimpleTriggerRadioButton.Checked = true;
-            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
+            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
+            this.procJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobSimpleTriggerRadioButton.Name = "procJobSimpleTriggerRadioButton";
-            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
+            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
             this.procJobSimpleTriggerRadioButton.TabIndex = 15;
             this.procJobSimpleTriggerRadioButton.TabStop = true;
             this.procJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -926,28 +966,30 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobCronExpressionLabel
             // 
             this.procJobCronExpressionLabel.AutoSize = true;
-            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(6, 79);
+            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(9, 122);
+            this.procJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.procJobCronExpressionLabel.Name = "procJobCronExpressionLabel";
-            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
+            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
             this.procJobCronExpressionLabel.TabIndex = 37;
             this.procJobCronExpressionLabel.Text = "Cron expression";
             // 
             // procJobCronExpressionTextBox
             // 
             this.procJobCronExpressionTextBox.Enabled = false;
-            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 95);
+            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 146);
+            this.procJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobCronExpressionTextBox.Name = "procJobCronExpressionTextBox";
-            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
+            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
             this.procJobCronExpressionTextBox.TabIndex = 36;
             this.procJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // procJobMinutesLabel
             // 
             this.procJobMinutesLabel.AutoSize = true;
-            this.procJobMinutesLabel.Location = new System.Drawing.Point(64, 25);
+            this.procJobMinutesLabel.Location = new System.Drawing.Point(96, 38);
             this.procJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobMinutesLabel.Name = "procJobMinutesLabel";
-            this.procJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
+            this.procJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
             this.procJobMinutesLabel.TabIndex = 32;
             this.procJobMinutesLabel.Text = "M:";
             this.procJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -955,10 +997,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobHoursLabel
             // 
             this.procJobHoursLabel.AutoSize = true;
-            this.procJobHoursLabel.Location = new System.Drawing.Point(6, 25);
+            this.procJobHoursLabel.Location = new System.Drawing.Point(9, 38);
             this.procJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobHoursLabel.Name = "procJobHoursLabel";
-            this.procJobHoursLabel.Size = new System.Drawing.Size(18, 13);
+            this.procJobHoursLabel.Size = new System.Drawing.Size(25, 20);
             this.procJobHoursLabel.TabIndex = 31;
             this.procJobHoursLabel.Text = "H:";
             this.procJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -966,9 +1008,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobStartAtLabel
             // 
             this.procJobStartAtLabel.AutoSize = true;
-            this.procJobStartAtLabel.Location = new System.Drawing.Point(126, 25);
+            this.procJobStartAtLabel.Location = new System.Drawing.Point(189, 38);
+            this.procJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.procJobStartAtLabel.Name = "procJobStartAtLabel";
-            this.procJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
+            this.procJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
             this.procJobStartAtLabel.TabIndex = 30;
             this.procJobStartAtLabel.Text = "start at";
             this.procJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -977,10 +1020,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.procJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 22);
+            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 34);
+            this.procJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobStartAtDateTimePicker.Name = "procJobStartAtDateTimePicker";
             this.procJobStartAtDateTimePicker.ShowUpDown = true;
-            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
+            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
             this.procJobStartAtDateTimePicker.TabIndex = 35;
             this.procJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -988,10 +1032,11 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobMinutesDateTimePicker.CustomFormat = "mm";
             this.procJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 22);
+            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 34);
+            this.procJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobMinutesDateTimePicker.Name = "procJobMinutesDateTimePicker";
             this.procJobMinutesDateTimePicker.ShowUpDown = true;
-            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.procJobMinutesDateTimePicker.TabIndex = 34;
             this.procJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 30, 0, 0);
             // 
@@ -999,19 +1044,21 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobHoursDateTimePicker.CustomFormat = "HH";
             this.procJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 22);
+            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 34);
+            this.procJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.procJobHoursDateTimePicker.Name = "procJobHoursDateTimePicker";
             this.procJobHoursDateTimePicker.ShowUpDown = true;
-            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
+            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
             this.procJobHoursDateTimePicker.TabIndex = 33;
             this.procJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
             // useMonitoringJobCheckBox
             // 
             this.useMonitoringJobCheckBox.AutoSize = true;
-            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(249, 284);
+            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(374, 437);
+            this.useMonitoringJobCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.useMonitoringJobCheckBox.Name = "useMonitoringJobCheckBox";
-            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(113, 17);
+            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(167, 24);
             this.useMonitoringJobCheckBox.TabIndex = 0;
             this.useMonitoringJobCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_monitoring_job;
             this.useMonitoringJobCheckBox.UseVisualStyleBackColor = true;
@@ -1025,11 +1072,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.fileSelectionGroupBox.Controls.Add(this.orderLabel);
             this.fileSelectionGroupBox.Controls.Add(this.orderByLabel);
             this.fileSelectionGroupBox.Controls.Add(this.searchPatternLabel);
-            this.fileSelectionGroupBox.Location = new System.Drawing.Point(250, 13);
-            this.fileSelectionGroupBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.fileSelectionGroupBox.Location = new System.Drawing.Point(375, 20);
             this.fileSelectionGroupBox.Name = "fileSelectionGroupBox";
-            this.fileSelectionGroupBox.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.fileSelectionGroupBox.Size = new System.Drawing.Size(230, 97);
+            this.fileSelectionGroupBox.Size = new System.Drawing.Size(345, 149);
             this.fileSelectionGroupBox.TabIndex = 5;
             this.fileSelectionGroupBox.TabStop = false;
             this.fileSelectionGroupBox.Text = "Files filter and order";
@@ -1038,29 +1083,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderByComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.orderByComboBox.FormattingEnabled = true;
-            this.orderByComboBox.Location = new System.Drawing.Point(58, 41);
-            this.orderByComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.orderByComboBox.Location = new System.Drawing.Point(87, 63);
             this.orderByComboBox.Name = "orderByComboBox";
-            this.orderByComboBox.Size = new System.Drawing.Size(168, 21);
+            this.orderByComboBox.Size = new System.Drawing.Size(250, 28);
             this.orderByComboBox.TabIndex = 5;
             // 
             // panel1
             // 
             this.panel1.Controls.Add(this.orderDescendingRadioButton);
             this.panel1.Controls.Add(this.orderAscendingRadioButton);
-            this.panel1.Location = new System.Drawing.Point(44, 67);
+            this.panel1.Location = new System.Drawing.Point(66, 103);
             this.panel1.Margin = new System.Windows.Forms.Padding(0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(182, 24);
+            this.panel1.Size = new System.Drawing.Size(273, 37);
             this.panel1.TabIndex = 4;
             // 
             // orderDescendingRadioButton
             // 
             this.orderDescendingRadioButton.AutoSize = true;
-            this.orderDescendingRadioButton.Location = new System.Drawing.Point(100, 2);
+            this.orderDescendingRadioButton.Location = new System.Drawing.Point(150, 3);
             this.orderDescendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderDescendingRadioButton.Name = "orderDescendingRadioButton";
-            this.orderDescendingRadioButton.Size = new System.Drawing.Size(82, 17);
+            this.orderDescendingRadioButton.Size = new System.Drawing.Size(119, 24);
             this.orderDescendingRadioButton.TabIndex = 1;
             this.orderDescendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Descending;
             this.orderDescendingRadioButton.UseVisualStyleBackColor = true;
@@ -1069,10 +1113,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderAscendingRadioButton.AutoSize = true;
             this.orderAscendingRadioButton.Checked = true;
-            this.orderAscendingRadioButton.Location = new System.Drawing.Point(4, 2);
+            this.orderAscendingRadioButton.Location = new System.Drawing.Point(6, 3);
             this.orderAscendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderAscendingRadioButton.Name = "orderAscendingRadioButton";
-            this.orderAscendingRadioButton.Size = new System.Drawing.Size(75, 17);
+            this.orderAscendingRadioButton.Size = new System.Drawing.Size(109, 24);
             this.orderAscendingRadioButton.TabIndex = 0;
             this.orderAscendingRadioButton.TabStop = true;
             this.orderAscendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Ascending;
@@ -1080,40 +1124,36 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // searchPatternTextBox
             // 
-            this.searchPatternTextBox.Location = new System.Drawing.Point(86, 18);
-            this.searchPatternTextBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.searchPatternTextBox.Location = new System.Drawing.Point(129, 28);
             this.searchPatternTextBox.Name = "searchPatternTextBox";
-            this.searchPatternTextBox.Size = new System.Drawing.Size(140, 20);
+            this.searchPatternTextBox.Size = new System.Drawing.Size(208, 26);
             this.searchPatternTextBox.TabIndex = 3;
             this.searchPatternTextBox.Text = "*.*";
             // 
             // orderLabel
             // 
             this.orderLabel.AutoSize = true;
-            this.orderLabel.Location = new System.Drawing.Point(4, 67);
-            this.orderLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.orderLabel.Location = new System.Drawing.Point(6, 103);
             this.orderLabel.Name = "orderLabel";
-            this.orderLabel.Size = new System.Drawing.Size(33, 13);
+            this.orderLabel.Size = new System.Drawing.Size(49, 20);
             this.orderLabel.TabIndex = 2;
             this.orderLabel.Text = "Order";
             // 
             // orderByLabel
             // 
             this.orderByLabel.AutoSize = true;
-            this.orderByLabel.Location = new System.Drawing.Point(4, 43);
-            this.orderByLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.orderByLabel.Location = new System.Drawing.Point(6, 66);
             this.orderByLabel.Name = "orderByLabel";
-            this.orderByLabel.Size = new System.Drawing.Size(47, 13);
+            this.orderByLabel.Size = new System.Drawing.Size(69, 20);
             this.orderByLabel.TabIndex = 1;
             this.orderByLabel.Text = "Order by";
             // 
             // searchPatternLabel
             // 
             this.searchPatternLabel.AutoSize = true;
-            this.searchPatternLabel.Location = new System.Drawing.Point(4, 20);
-            this.searchPatternLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.searchPatternLabel.Location = new System.Drawing.Point(6, 31);
             this.searchPatternLabel.Name = "searchPatternLabel";
-            this.searchPatternLabel.Size = new System.Drawing.Size(77, 13);
+            this.searchPatternLabel.Size = new System.Drawing.Size(115, 20);
             this.searchPatternLabel.TabIndex = 0;
             this.searchPatternLabel.Text = "Search pattern";
             // 
@@ -1123,23 +1163,26 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(249, 436);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(374, 671);
+            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 93);
+            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 118);
             this.retryPolicyGroupBox.TabIndex = 6;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(100, 42);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(150, 65);
+            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesDelayUpDown.TabIndex = 5;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -1149,14 +1192,15 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(100, 18);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(150, 28);
+            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
             this.retriesCountUpDown.TabIndex = 4;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -1167,29 +1211,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(7, 44);
+            this.label2.Location = new System.Drawing.Point(10, 68);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 13);
+            this.label2.Size = new System.Drawing.Size(123, 20);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(7, 20);
+            this.label1.Location = new System.Drawing.Point(10, 31);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(87, 13);
+            this.label1.Size = new System.Drawing.Size(131, 20);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(486, 475);
-            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(729, 731);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 38);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 58);
             this.groupBoxExceptions.TabIndex = 10;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -1199,32 +1243,50 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
-            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(14, 26);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
-            // pauseIndefinitelyCheckBox
+            // groupBoxButtons
             // 
-            this.pauseIndefinitelyCheckBox.AutoSize = true;
-            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(9, 17);
-            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
-            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
-            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
-            this.pauseIndefinitelyCheckBox.TabIndex = 0;
-            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
-            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            this.groupBoxButtons.Controls.Add(this.addJobButton);
+            this.groupBoxButtons.Controls.Add(this.cancelButton);
+            this.groupBoxButtons.Location = new System.Drawing.Point(20, 797);
+            this.groupBoxButtons.Name = "groupBoxButtons";
+            this.groupBoxButtons.Size = new System.Drawing.Size(1054, 73);
+            this.groupBoxButtons.TabIndex = 12;
+            this.groupBoxButtons.TabStop = false;
+            // 
+            // addJobButton
+            // 
+            this.addJobButton.Location = new System.Drawing.Point(709, 25);
+            this.addJobButton.Name = "addJobButton";
+            this.addJobButton.Size = new System.Drawing.Size(162, 34);
+            this.addJobButton.TabIndex = 2;
+            this.addJobButton.Text = "Add to schedule";
+            this.addJobButton.UseVisualStyleBackColor = true;
+            this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.Location = new System.Drawing.Point(886, 25);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(162, 34);
+            this.cancelButton.TabIndex = 1;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
             // 
             // UploadJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(723, 540);
-            this.Controls.Add(this.bottomToolStrip);
+            this.ClientSize = new System.Drawing.Size(1076, 879);
+            this.Controls.Add(this.groupBoxButtons);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.retryPolicyGroupBox);
             this.Controls.Add(this.fileSelectionGroupBox);
@@ -1234,10 +1296,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.Controls.Add(this.jobDetailsGroupBox);
             this.Controls.Add(this.useMonitoringJobCheckBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(739, 579);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(739, 579);
+            this.MinimumSize = new System.Drawing.Size(1098, 861);
             this.Name = "UploadJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -1254,8 +1316,6 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.PerformLayout();
             this.upJobTriggerTypePanel.ResumeLayout(false);
             this.upJobTriggerTypePanel.PerformLayout();
-            this.bottomToolStrip.ResumeLayout(false);
-            this.bottomToolStrip.PerformLayout();
             this.processingJobGroupBox.ResumeLayout(false);
             this.processingJobGroupBox.PerformLayout();
             this.procJobTriggerTypePanel.ResumeLayout(false);
@@ -1270,6 +1330,7 @@ namespace RecurringIntegrationsScheduler.Forms
             ((System.ComponentModel.ISupportInitialize)(this.retriesCountUpDown)).EndInit();
             this.groupBoxExceptions.ResumeLayout(false);
             this.groupBoxExceptions.PerformLayout();
+            this.groupBoxButtons.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1314,7 +1375,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.Panel upJobTriggerTypePanel;
         private System.Windows.Forms.RadioButton upJobCronTriggerRadioButton;
         private System.Windows.Forms.RadioButton upJobSimpleTriggerRadioButton;
-        private System.Windows.Forms.ToolStrip bottomToolStrip;
         private System.Windows.Forms.LinkLabel cronDocsLinkLabel;
         private System.Windows.Forms.TextBox calculatedRunsTextBox;
         private System.Windows.Forms.Button getCronScheduleForUploadButton;
@@ -1342,8 +1402,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.DateTimePicker procJobStartAtDateTimePicker;
         private System.Windows.Forms.DateTimePicker procJobMinutesDateTimePicker;
         private System.Windows.Forms.DateTimePicker procJobHoursDateTimePicker;
-        private System.Windows.Forms.ToolStripButton addJobButton;
-        private System.Windows.Forms.ToolStripButton cancelButton;
         private System.Windows.Forms.Button getCronScheduleForProcButton;
         private System.Windows.Forms.Label LegalEntityLabel;
         private System.Windows.Forms.TextBox statusFileExtensionTextBox;
@@ -1375,5 +1433,8 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
         private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
+        private System.Windows.Forms.GroupBox groupBoxButtons;
+        private System.Windows.Forms.Button addJobButton;
+        private System.Windows.Forms.Button cancelButton;
     }
 }

--- a/Scheduler/Forms/UploadJob.Designer.cs
+++ b/Scheduler/Forms/UploadJob.Designer.cs
@@ -128,6 +128,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.groupBoxExceptions = new System.Windows.Forms.GroupBox();
             this.pauseOnExceptionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.pauseIndefinitelyCheckBox = new System.Windows.Forms.CheckBox();
             this.jobDetailsGroupBox.SuspendLayout();
             this.axDetailsGroupBox.SuspendLayout();
             this.authMethodPanel.SuspendLayout();
@@ -176,11 +177,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.jobDetailsGroupBox.Controls.Add(this.jobGroupLabel);
             this.jobDetailsGroupBox.Controls.Add(this.jobName);
             this.jobDetailsGroupBox.Controls.Add(this.jobNameLabel);
-            this.jobDetailsGroupBox.Location = new System.Drawing.Point(20, 20);
-            this.jobDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDetailsGroupBox.Location = new System.Drawing.Point(13, 13);
             this.jobDetailsGroupBox.Name = "jobDetailsGroupBox";
-            this.jobDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.jobDetailsGroupBox.Size = new System.Drawing.Size(344, 738);
+            this.jobDetailsGroupBox.Size = new System.Drawing.Size(229, 480);
             this.jobDetailsGroupBox.TabIndex = 0;
             this.jobDetailsGroupBox.TabStop = false;
             this.jobDetailsGroupBox.Text = "Job details";
@@ -190,10 +189,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingErrorsFolderBrowserButton.Enabled = false;
             this.processingErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 566);
+            this.processingErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 368);
             this.processingErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingErrorsFolderBrowserButton.Name = "processingErrorsFolderBrowserButton";
-            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.processingErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.processingErrorsFolderBrowserButton.TabIndex = 27;
             this.processingErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -202,29 +201,26 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingErrorsFolderTextBox
             // 
             this.processingErrorsFolderTextBox.Enabled = false;
-            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(16, 572);
-            this.processingErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingErrorsFolderTextBox.Location = new System.Drawing.Point(11, 372);
             this.processingErrorsFolderTextBox.Name = "processingErrorsFolderTextBox";
-            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.processingErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.processingErrorsFolderTextBox.TabIndex = 26;
             // 
             // processingErrorsFolderLabel
             // 
             this.processingErrorsFolderLabel.AutoSize = true;
-            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(12, 545);
-            this.processingErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.processingErrorsFolderLabel.Location = new System.Drawing.Point(8, 354);
             this.processingErrorsFolderLabel.Name = "processingErrorsFolderLabel";
-            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(176, 20);
+            this.processingErrorsFolderLabel.Size = new System.Drawing.Size(117, 13);
             this.processingErrorsFolderLabel.TabIndex = 28;
             this.processingErrorsFolderLabel.Text = "Processing errors folder";
             // 
             // statusFileExtensionTextBox
             // 
             this.statusFileExtensionTextBox.Enabled = false;
-            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(213, 698);
-            this.statusFileExtensionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.statusFileExtensionTextBox.Location = new System.Drawing.Point(142, 454);
             this.statusFileExtensionTextBox.Name = "statusFileExtensionTextBox";
-            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(118, 26);
+            this.statusFileExtensionTextBox.Size = new System.Drawing.Size(80, 20);
             this.statusFileExtensionTextBox.TabIndex = 25;
             this.statusFileExtensionTextBox.Text = ".Status";
             this.statusFileExtensionTextBox.Leave += new System.EventHandler(this.StatusFileExtensionTextBox_Leave);
@@ -232,10 +228,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // statusFileExtensionLabel
             // 
             this.statusFileExtensionLabel.AutoSize = true;
-            this.statusFileExtensionLabel.Location = new System.Drawing.Point(54, 703);
-            this.statusFileExtensionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.statusFileExtensionLabel.Location = new System.Drawing.Point(36, 457);
             this.statusFileExtensionLabel.Name = "statusFileExtensionLabel";
-            this.statusFileExtensionLabel.Size = new System.Drawing.Size(152, 20);
+            this.statusFileExtensionLabel.Size = new System.Drawing.Size(101, 13);
             this.statusFileExtensionLabel.TabIndex = 24;
             this.statusFileExtensionLabel.Text = "Status file extension";
             // 
@@ -243,29 +238,26 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.dataPackageCheckBox.AutoSize = true;
             this.dataPackageCheckBox.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.dataPackageCheckBox.Location = new System.Drawing.Point(18, 625);
-            this.dataPackageCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.dataPackageCheckBox.Location = new System.Drawing.Point(12, 406);
             this.dataPackageCheckBox.Name = "dataPackageCheckBox";
-            this.dataPackageCheckBox.Size = new System.Drawing.Size(216, 24);
+            this.dataPackageCheckBox.Size = new System.Drawing.Size(148, 17);
             this.dataPackageCheckBox.TabIndex = 23;
             this.dataPackageCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Uploading_data_packages;
             this.dataPackageCheckBox.UseVisualStyleBackColor = true;
             // 
             // legalEntityTextBox
             // 
-            this.legalEntityTextBox.Location = new System.Drawing.Point(213, 662);
-            this.legalEntityTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.legalEntityTextBox.Location = new System.Drawing.Point(142, 430);
             this.legalEntityTextBox.Name = "legalEntityTextBox";
-            this.legalEntityTextBox.Size = new System.Drawing.Size(118, 26);
+            this.legalEntityTextBox.Size = new System.Drawing.Size(80, 20);
             this.legalEntityTextBox.TabIndex = 22;
             // 
             // LegalEntityLabel
             // 
             this.LegalEntityLabel.AutoSize = true;
-            this.LegalEntityLabel.Location = new System.Drawing.Point(42, 665);
-            this.LegalEntityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LegalEntityLabel.Location = new System.Drawing.Point(28, 432);
             this.LegalEntityLabel.Name = "LegalEntityLabel";
-            this.LegalEntityLabel.Size = new System.Drawing.Size(160, 20);
+            this.LegalEntityLabel.Size = new System.Drawing.Size(107, 13);
             this.LegalEntityLabel.TabIndex = 21;
             this.LegalEntityLabel.Text = "Legal entity (optional)";
             // 
@@ -274,10 +266,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.inputFolderBrowserButton.Enabled = false;
             this.inputFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.inputFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.inputFolderBrowserButton.Location = new System.Drawing.Point(300, 322);
+            this.inputFolderBrowserButton.Location = new System.Drawing.Point(200, 209);
             this.inputFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.inputFolderBrowserButton.Name = "inputFolderBrowserButton";
-            this.inputFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.inputFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.inputFolderBrowserButton.TabIndex = 19;
             this.inputFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.inputFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -286,19 +278,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // inputFolderTextBox
             // 
             this.inputFolderTextBox.Enabled = false;
-            this.inputFolderTextBox.Location = new System.Drawing.Point(16, 328);
-            this.inputFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.inputFolderTextBox.Location = new System.Drawing.Point(11, 213);
             this.inputFolderTextBox.Name = "inputFolderTextBox";
-            this.inputFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.inputFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.inputFolderTextBox.TabIndex = 18;
             // 
             // inputFolderLabel
             // 
             this.inputFolderLabel.AutoSize = true;
-            this.inputFolderLabel.Location = new System.Drawing.Point(12, 300);
-            this.inputFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.inputFolderLabel.Location = new System.Drawing.Point(8, 195);
             this.inputFolderLabel.Name = "inputFolderLabel";
-            this.inputFolderLabel.Size = new System.Drawing.Size(116, 20);
+            this.inputFolderLabel.Size = new System.Drawing.Size(77, 13);
             this.inputFolderLabel.TabIndex = 20;
             this.inputFolderLabel.Text = "Input subfolder";
             // 
@@ -307,10 +297,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingSuccessFolderBrowserButton.Enabled = false;
             this.processingSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.processingSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 505);
+            this.processingSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 328);
             this.processingSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.processingSuccessFolderBrowserButton.Name = "processingSuccessFolderBrowserButton";
-            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.processingSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.processingSuccessFolderBrowserButton.TabIndex = 16;
             this.processingSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.processingSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -319,19 +309,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // processingSuccessFolderTextBox
             // 
             this.processingSuccessFolderTextBox.Enabled = false;
-            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(16, 511);
-            this.processingSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingSuccessFolderTextBox.Location = new System.Drawing.Point(11, 332);
             this.processingSuccessFolderTextBox.Name = "processingSuccessFolderTextBox";
-            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.processingSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.processingSuccessFolderTextBox.TabIndex = 15;
             // 
             // processingSuccessFolderLabel
             // 
             this.processingSuccessFolderLabel.AutoSize = true;
-            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(12, 483);
-            this.processingSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.processingSuccessFolderLabel.Location = new System.Drawing.Point(8, 314);
             this.processingSuccessFolderLabel.Name = "processingSuccessFolderLabel";
-            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(193, 20);
+            this.processingSuccessFolderLabel.Size = new System.Drawing.Size(130, 13);
             this.processingSuccessFolderLabel.TabIndex = 17;
             this.processingSuccessFolderLabel.Text = "Processing success folder";
             // 
@@ -340,10 +328,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadSuccessFolderBrowserButton.Enabled = false;
             this.uploadSuccessFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadSuccessFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(300, 383);
+            this.uploadSuccessFolderBrowserButton.Location = new System.Drawing.Point(200, 249);
             this.uploadSuccessFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadSuccessFolderBrowserButton.Name = "uploadSuccessFolderBrowserButton";
-            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.uploadSuccessFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.uploadSuccessFolderBrowserButton.TabIndex = 13;
             this.uploadSuccessFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadSuccessFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -352,19 +340,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadSuccessFolderTextBox
             // 
             this.uploadSuccessFolderTextBox.Enabled = false;
-            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(16, 389);
-            this.uploadSuccessFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.uploadSuccessFolderTextBox.Location = new System.Drawing.Point(11, 253);
             this.uploadSuccessFolderTextBox.Name = "uploadSuccessFolderTextBox";
-            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.uploadSuccessFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.uploadSuccessFolderTextBox.TabIndex = 12;
             // 
             // uploadSuccessFolderLabel
             // 
             this.uploadSuccessFolderLabel.AutoSize = true;
-            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(12, 362);
-            this.uploadSuccessFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.uploadSuccessFolderLabel.Location = new System.Drawing.Point(8, 235);
             this.uploadSuccessFolderLabel.Name = "uploadSuccessFolderLabel";
-            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(166, 20);
+            this.uploadSuccessFolderLabel.Size = new System.Drawing.Size(112, 13);
             this.uploadSuccessFolderLabel.TabIndex = 14;
             this.uploadSuccessFolderLabel.Text = "Upload success folder";
             // 
@@ -373,10 +359,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.useStandardSubfolder.AutoSize = true;
             this.useStandardSubfolder.Checked = true;
             this.useStandardSubfolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.useStandardSubfolder.Location = new System.Drawing.Point(15, 268);
-            this.useStandardSubfolder.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.useStandardSubfolder.Location = new System.Drawing.Point(10, 174);
             this.useStandardSubfolder.Name = "useStandardSubfolder";
-            this.useStandardSubfolder.Size = new System.Drawing.Size(247, 24);
+            this.useStandardSubfolder.Size = new System.Drawing.Size(165, 17);
             this.useStandardSubfolder.TabIndex = 8;
             this.useStandardSubfolder.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Use_default_subfolders_names;
             this.useStandardSubfolder.UseVisualStyleBackColor = true;
@@ -387,10 +372,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.uploadErrorsFolderBrowserButton.Enabled = false;
             this.uploadErrorsFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.uploadErrorsFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(300, 443);
+            this.uploadErrorsFolderBrowserButton.Location = new System.Drawing.Point(200, 288);
             this.uploadErrorsFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.uploadErrorsFolderBrowserButton.Name = "uploadErrorsFolderBrowserButton";
-            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.uploadErrorsFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.uploadErrorsFolderBrowserButton.TabIndex = 7;
             this.uploadErrorsFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.uploadErrorsFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -399,19 +384,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // uploadErrorsFolderTextBox
             // 
             this.uploadErrorsFolderTextBox.Enabled = false;
-            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(16, 449);
-            this.uploadErrorsFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.uploadErrorsFolderTextBox.Location = new System.Drawing.Point(11, 292);
             this.uploadErrorsFolderTextBox.Name = "uploadErrorsFolderTextBox";
-            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.uploadErrorsFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.uploadErrorsFolderTextBox.TabIndex = 6;
             // 
             // uploadErrorsFolderLabel
             // 
             this.uploadErrorsFolderLabel.AutoSize = true;
-            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(12, 423);
-            this.uploadErrorsFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.uploadErrorsFolderLabel.Location = new System.Drawing.Point(8, 275);
             this.uploadErrorsFolderLabel.Name = "uploadErrorsFolderLabel";
-            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(149, 20);
+            this.uploadErrorsFolderLabel.Size = new System.Drawing.Size(99, 13);
             this.uploadErrorsFolderLabel.TabIndex = 11;
             this.uploadErrorsFolderLabel.Text = "Upload errors folder";
             // 
@@ -419,10 +402,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.topUploadFolderBrowserButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
             this.topUploadFolderBrowserButton.Image = global::RecurringIntegrationsScheduler.Properties.Resources.Folder_open_32xMD_exp;
-            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(300, 228);
+            this.topUploadFolderBrowserButton.Location = new System.Drawing.Point(200, 148);
             this.topUploadFolderBrowserButton.Margin = new System.Windows.Forms.Padding(0);
             this.topUploadFolderBrowserButton.Name = "topUploadFolderBrowserButton";
-            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(36, 40);
+            this.topUploadFolderBrowserButton.Size = new System.Drawing.Size(24, 26);
             this.topUploadFolderBrowserButton.TabIndex = 5;
             this.topUploadFolderBrowserButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.topUploadFolderBrowserButton.UseVisualStyleBackColor = true;
@@ -430,39 +413,35 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // topUploadFolderTextBox
             // 
-            this.topUploadFolderTextBox.Location = new System.Drawing.Point(16, 234);
-            this.topUploadFolderTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.topUploadFolderTextBox.Location = new System.Drawing.Point(11, 152);
             this.topUploadFolderTextBox.Name = "topUploadFolderTextBox";
-            this.topUploadFolderTextBox.Size = new System.Drawing.Size(278, 26);
+            this.topUploadFolderTextBox.Size = new System.Drawing.Size(187, 20);
             this.topUploadFolderTextBox.TabIndex = 4;
             this.topUploadFolderTextBox.TextChanged += new System.EventHandler(this.TopUploadFolder_TextChanged);
             // 
             // topUploadFolderLabel
             // 
             this.topUploadFolderLabel.AutoSize = true;
-            this.topUploadFolderLabel.Location = new System.Drawing.Point(12, 206);
-            this.topUploadFolderLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.topUploadFolderLabel.Location = new System.Drawing.Point(8, 134);
             this.topUploadFolderLabel.Name = "topUploadFolderLabel";
-            this.topUploadFolderLabel.Size = new System.Drawing.Size(132, 20);
+            this.topUploadFolderLabel.Size = new System.Drawing.Size(90, 13);
             this.topUploadFolderLabel.TabIndex = 8;
             this.topUploadFolderLabel.Text = "Top upload folder";
             // 
             // jobDescription
             // 
-            this.jobDescription.Location = new System.Drawing.Point(18, 145);
-            this.jobDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobDescription.Location = new System.Drawing.Point(12, 94);
             this.jobDescription.Multiline = true;
             this.jobDescription.Name = "jobDescription";
-            this.jobDescription.Size = new System.Drawing.Size(314, 53);
+            this.jobDescription.Size = new System.Drawing.Size(211, 36);
             this.jobDescription.TabIndex = 3;
             // 
             // jobDescriptionLabel
             // 
             this.jobDescriptionLabel.AutoSize = true;
-            this.jobDescriptionLabel.Location = new System.Drawing.Point(12, 117);
-            this.jobDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobDescriptionLabel.Location = new System.Drawing.Point(8, 76);
             this.jobDescriptionLabel.Name = "jobDescriptionLabel";
-            this.jobDescriptionLabel.Size = new System.Drawing.Size(89, 20);
+            this.jobDescriptionLabel.Size = new System.Drawing.Size(60, 13);
             this.jobDescriptionLabel.TabIndex = 4;
             this.jobDescriptionLabel.Text = "Description";
             // 
@@ -470,38 +449,34 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.jobGroupComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.jobGroupComboBox.FormattingEnabled = true;
-            this.jobGroupComboBox.Location = new System.Drawing.Point(75, 75);
-            this.jobGroupComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobGroupComboBox.Location = new System.Drawing.Point(50, 49);
             this.jobGroupComboBox.Name = "jobGroupComboBox";
-            this.jobGroupComboBox.Size = new System.Drawing.Size(258, 28);
+            this.jobGroupComboBox.Size = new System.Drawing.Size(173, 21);
             this.jobGroupComboBox.Sorted = true;
             this.jobGroupComboBox.TabIndex = 2;
             // 
             // jobGroupLabel
             // 
             this.jobGroupLabel.AutoSize = true;
-            this.jobGroupLabel.Location = new System.Drawing.Point(12, 80);
-            this.jobGroupLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobGroupLabel.Location = new System.Drawing.Point(8, 52);
             this.jobGroupLabel.Name = "jobGroupLabel";
-            this.jobGroupLabel.Size = new System.Drawing.Size(54, 20);
+            this.jobGroupLabel.Size = new System.Drawing.Size(36, 13);
             this.jobGroupLabel.TabIndex = 2;
             this.jobGroupLabel.Text = "Group";
             // 
             // jobName
             // 
-            this.jobName.Location = new System.Drawing.Point(75, 26);
-            this.jobName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.jobName.Location = new System.Drawing.Point(50, 17);
             this.jobName.Name = "jobName";
-            this.jobName.Size = new System.Drawing.Size(258, 26);
+            this.jobName.Size = new System.Drawing.Size(173, 20);
             this.jobName.TabIndex = 1;
             // 
             // jobNameLabel
             // 
             this.jobNameLabel.AutoSize = true;
-            this.jobNameLabel.Location = new System.Drawing.Point(12, 31);
-            this.jobNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.jobNameLabel.Location = new System.Drawing.Point(8, 20);
             this.jobNameLabel.Name = "jobNameLabel";
-            this.jobNameLabel.Size = new System.Drawing.Size(51, 20);
+            this.jobNameLabel.Size = new System.Drawing.Size(35, 13);
             this.jobNameLabel.TabIndex = 0;
             this.jobNameLabel.Text = "Name";
             // 
@@ -516,11 +491,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.axDetailsGroupBox.Controls.Add(this.userComboBox);
             this.axDetailsGroupBox.Controls.Add(this.instanceLabel);
             this.axDetailsGroupBox.Controls.Add(this.instanceComboBox);
-            this.axDetailsGroupBox.Location = new System.Drawing.Point(375, 177);
-            this.axDetailsGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.axDetailsGroupBox.Location = new System.Drawing.Point(250, 115);
             this.axDetailsGroupBox.Name = "axDetailsGroupBox";
-            this.axDetailsGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.axDetailsGroupBox.Size = new System.Drawing.Size(345, 248);
+            this.axDetailsGroupBox.Size = new System.Drawing.Size(230, 161);
             this.axDetailsGroupBox.TabIndex = 1;
             this.axDetailsGroupBox.TabStop = false;
             this.axDetailsGroupBox.Text = "Dynamics details";
@@ -528,10 +501,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // aadApplicationLabel
             // 
             this.aadApplicationLabel.AutoSize = true;
-            this.aadApplicationLabel.Location = new System.Drawing.Point(18, 162);
-            this.aadApplicationLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.aadApplicationLabel.Location = new System.Drawing.Point(12, 105);
             this.aadApplicationLabel.Name = "aadApplicationLabel";
-            this.aadApplicationLabel.Size = new System.Drawing.Size(123, 20);
+            this.aadApplicationLabel.Size = new System.Drawing.Size(83, 13);
             this.aadApplicationLabel.TabIndex = 32;
             this.aadApplicationLabel.Text = "AAD application";
             // 
@@ -539,29 +511,26 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.aadApplicationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.aadApplicationComboBox.FormattingEnabled = true;
-            this.aadApplicationComboBox.Location = new System.Drawing.Point(159, 157);
-            this.aadApplicationComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.aadApplicationComboBox.Location = new System.Drawing.Point(106, 102);
             this.aadApplicationComboBox.Name = "aadApplicationComboBox";
-            this.aadApplicationComboBox.Size = new System.Drawing.Size(174, 28);
+            this.aadApplicationComboBox.Size = new System.Drawing.Size(117, 21);
             this.aadApplicationComboBox.TabIndex = 31;
             // 
             // authMethodPanel
             // 
             this.authMethodPanel.Controls.Add(this.serviceAuthRadioButton);
             this.authMethodPanel.Controls.Add(this.userAuthRadioButton);
-            this.authMethodPanel.Location = new System.Drawing.Point(12, 109);
-            this.authMethodPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.authMethodPanel.Location = new System.Drawing.Point(8, 71);
             this.authMethodPanel.Name = "authMethodPanel";
-            this.authMethodPanel.Size = new System.Drawing.Size(321, 38);
+            this.authMethodPanel.Size = new System.Drawing.Size(214, 25);
             this.authMethodPanel.TabIndex = 30;
             // 
             // serviceAuthRadioButton
             // 
             this.serviceAuthRadioButton.AutoSize = true;
-            this.serviceAuthRadioButton.Location = new System.Drawing.Point(177, 5);
-            this.serviceAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.serviceAuthRadioButton.Location = new System.Drawing.Point(118, 3);
             this.serviceAuthRadioButton.Name = "serviceAuthRadioButton";
-            this.serviceAuthRadioButton.Size = new System.Drawing.Size(122, 24);
+            this.serviceAuthRadioButton.Size = new System.Drawing.Size(85, 17);
             this.serviceAuthRadioButton.TabIndex = 16;
             this.serviceAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Service_auth;
             this.serviceAuthRadioButton.UseVisualStyleBackColor = true;
@@ -571,10 +540,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userAuthRadioButton.AutoSize = true;
             this.userAuthRadioButton.Checked = true;
-            this.userAuthRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.userAuthRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userAuthRadioButton.Location = new System.Drawing.Point(3, 3);
             this.userAuthRadioButton.Name = "userAuthRadioButton";
-            this.userAuthRadioButton.Size = new System.Drawing.Size(104, 24);
+            this.userAuthRadioButton.Size = new System.Drawing.Size(71, 17);
             this.userAuthRadioButton.TabIndex = 15;
             this.userAuthRadioButton.TabStop = true;
             this.userAuthRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.User_auth;
@@ -583,10 +551,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // dataJobLabel
             // 
             this.dataJobLabel.AutoSize = true;
-            this.dataJobLabel.Location = new System.Drawing.Point(30, 72);
-            this.dataJobLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.dataJobLabel.Location = new System.Drawing.Point(20, 47);
             this.dataJobLabel.Name = "dataJobLabel";
-            this.dataJobLabel.Size = new System.Drawing.Size(69, 20);
+            this.dataJobLabel.Size = new System.Drawing.Size(47, 13);
             this.dataJobLabel.TabIndex = 22;
             this.dataJobLabel.Text = "Data job";
             // 
@@ -594,19 +561,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.dataJobComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.dataJobComboBox.FormattingEnabled = true;
-            this.dataJobComboBox.Location = new System.Drawing.Point(114, 69);
-            this.dataJobComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.dataJobComboBox.Location = new System.Drawing.Point(76, 45);
             this.dataJobComboBox.Name = "dataJobComboBox";
-            this.dataJobComboBox.Size = new System.Drawing.Size(218, 28);
+            this.dataJobComboBox.Size = new System.Drawing.Size(147, 21);
             this.dataJobComboBox.TabIndex = 11;
             // 
             // userLabel
             // 
             this.userLabel.AutoSize = true;
-            this.userLabel.Location = new System.Drawing.Point(102, 202);
-            this.userLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.userLabel.Location = new System.Drawing.Point(68, 131);
             this.userLabel.Name = "userLabel";
-            this.userLabel.Size = new System.Drawing.Size(43, 20);
+            this.userLabel.Size = new System.Drawing.Size(29, 13);
             this.userLabel.TabIndex = 19;
             this.userLabel.Text = "User";
             // 
@@ -614,19 +579,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.userComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.userComboBox.FormattingEnabled = true;
-            this.userComboBox.Location = new System.Drawing.Point(159, 197);
-            this.userComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.userComboBox.Location = new System.Drawing.Point(106, 128);
             this.userComboBox.Name = "userComboBox";
-            this.userComboBox.Size = new System.Drawing.Size(174, 28);
+            this.userComboBox.Size = new System.Drawing.Size(117, 21);
             this.userComboBox.TabIndex = 10;
             // 
             // instanceLabel
             // 
             this.instanceLabel.AutoSize = true;
-            this.instanceLabel.Location = new System.Drawing.Point(30, 34);
-            this.instanceLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.instanceLabel.Location = new System.Drawing.Point(20, 22);
             this.instanceLabel.Name = "instanceLabel";
-            this.instanceLabel.Size = new System.Drawing.Size(71, 20);
+            this.instanceLabel.Size = new System.Drawing.Size(48, 13);
             this.instanceLabel.TabIndex = 16;
             this.instanceLabel.Text = "Instance";
             // 
@@ -634,14 +597,14 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.instanceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.instanceComboBox.FormattingEnabled = true;
-            this.instanceComboBox.Location = new System.Drawing.Point(114, 29);
-            this.instanceComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.instanceComboBox.Location = new System.Drawing.Point(76, 19);
             this.instanceComboBox.Name = "instanceComboBox";
-            this.instanceComboBox.Size = new System.Drawing.Size(218, 28);
+            this.instanceComboBox.Size = new System.Drawing.Size(147, 21);
             this.instanceComboBox.TabIndex = 9;
             // 
             // recurrenceGroupBox
             // 
+            this.recurrenceGroupBox.Controls.Add(this.pauseIndefinitelyCheckBox);
             this.recurrenceGroupBox.Controls.Add(this.getCronScheduleForProcButton);
             this.recurrenceGroupBox.Controls.Add(this.moreExamplesButton);
             this.recurrenceGroupBox.Controls.Add(this.calculatedRunsTextBox);
@@ -659,11 +622,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.recurrenceGroupBox.Controls.Add(this.upJobStartAtDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobMinutesDateTimePicker);
             this.recurrenceGroupBox.Controls.Add(this.upJobHoursDateTimePicker);
-            this.recurrenceGroupBox.Location = new System.Drawing.Point(729, 20);
-            this.recurrenceGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.recurrenceGroupBox.Location = new System.Drawing.Point(486, 13);
             this.recurrenceGroupBox.Name = "recurrenceGroupBox";
-            this.recurrenceGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.recurrenceGroupBox.Size = new System.Drawing.Size(345, 634);
+            this.recurrenceGroupBox.Size = new System.Drawing.Size(230, 450);
             this.recurrenceGroupBox.TabIndex = 2;
             this.recurrenceGroupBox.TabStop = false;
             this.recurrenceGroupBox.Text = "Recurrence";
@@ -671,10 +632,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // getCronScheduleForProcButton
             // 
             this.getCronScheduleForProcButton.Enabled = false;
-            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(178, 472);
-            this.getCronScheduleForProcButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.getCronScheduleForProcButton.Location = new System.Drawing.Point(119, 336);
             this.getCronScheduleForProcButton.Name = "getCronScheduleForProcButton";
-            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(158, 55);
+            this.getCronScheduleForProcButton.Size = new System.Drawing.Size(105, 36);
             this.getCronScheduleForProcButton.TabIndex = 33;
             this.getCronScheduleForProcButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Get_cron_schedule_for_monitor_job;
             this.getCronScheduleForProcButton.UseVisualStyleBackColor = true;
@@ -682,10 +642,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // moreExamplesButton
             // 
-            this.moreExamplesButton.Location = new System.Drawing.Point(237, 534);
-            this.moreExamplesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.moreExamplesButton.Location = new System.Drawing.Point(158, 376);
             this.moreExamplesButton.Name = "moreExamplesButton";
-            this.moreExamplesButton.Size = new System.Drawing.Size(99, 85);
+            this.moreExamplesButton.Size = new System.Drawing.Size(66, 55);
             this.moreExamplesButton.TabIndex = 19;
             this.moreExamplesButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.More_examples;
             this.moreExamplesButton.UseVisualStyleBackColor = true;
@@ -694,22 +653,20 @@ namespace RecurringIntegrationsScheduler.Forms
             // calculatedRunsTextBox
             // 
             this.calculatedRunsTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.calculatedRunsTextBox.Location = new System.Drawing.Point(14, 534);
-            this.calculatedRunsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.calculatedRunsTextBox.Location = new System.Drawing.Point(9, 376);
             this.calculatedRunsTextBox.Multiline = true;
             this.calculatedRunsTextBox.Name = "calculatedRunsTextBox";
             this.calculatedRunsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.calculatedRunsTextBox.Size = new System.Drawing.Size(216, 82);
+            this.calculatedRunsTextBox.Size = new System.Drawing.Size(145, 55);
             this.calculatedRunsTextBox.TabIndex = 32;
             this.calculatedRunsTextBox.TabStop = false;
             // 
             // getCronScheduleForUploadButton
             // 
             this.getCronScheduleForUploadButton.Enabled = false;
-            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(14, 472);
-            this.getCronScheduleForUploadButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.getCronScheduleForUploadButton.Location = new System.Drawing.Point(9, 336);
             this.getCronScheduleForUploadButton.Name = "getCronScheduleForUploadButton";
-            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(158, 55);
+            this.getCronScheduleForUploadButton.Size = new System.Drawing.Size(105, 36);
             this.getCronScheduleForUploadButton.TabIndex = 18;
             this.getCronScheduleForUploadButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Get_cron_schedule_for_upload_job;
             this.getCronScheduleForUploadButton.UseVisualStyleBackColor = true;
@@ -718,10 +675,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronDocsLinkLabel
             // 
             this.cronDocsLinkLabel.AutoSize = true;
-            this.cronDocsLinkLabel.Location = new System.Drawing.Point(9, 443);
-            this.cronDocsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronDocsLinkLabel.Location = new System.Drawing.Point(6, 317);
             this.cronDocsLinkLabel.Name = "cronDocsLinkLabel";
-            this.cronDocsLinkLabel.Size = new System.Drawing.Size(259, 20);
+            this.cronDocsLinkLabel.Size = new System.Drawing.Size(172, 13);
             this.cronDocsLinkLabel.TabIndex = 30;
             this.cronDocsLinkLabel.TabStop = true;
             this.cronDocsLinkLabel.Text = "Quartz cron triggers documentation";
@@ -731,19 +687,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobTriggerTypePanel.Controls.Add(this.upJobCronTriggerRadioButton);
             this.upJobTriggerTypePanel.Controls.Add(this.upJobSimpleTriggerRadioButton);
-            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(14, 69);
-            this.upJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobTriggerTypePanel.Location = new System.Drawing.Point(9, 74);
             this.upJobTriggerTypePanel.Name = "upJobTriggerTypePanel";
-            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
+            this.upJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
             this.upJobTriggerTypePanel.TabIndex = 29;
             // 
             // upJobCronTriggerRadioButton
             // 
             this.upJobCronTriggerRadioButton.AutoSize = true;
-            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 5);
-            this.upJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 3);
             this.upJobCronTriggerRadioButton.Name = "upJobCronTriggerRadioButton";
-            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
+            this.upJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
             this.upJobCronTriggerRadioButton.TabIndex = 16;
             this.upJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.upJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -753,10 +707,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobSimpleTriggerRadioButton.AutoSize = true;
             this.upJobSimpleTriggerRadioButton.Checked = true;
-            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.upJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
             this.upJobSimpleTriggerRadioButton.Name = "upJobSimpleTriggerRadioButton";
-            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
+            this.upJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
             this.upJobSimpleTriggerRadioButton.TabIndex = 15;
             this.upJobSimpleTriggerRadioButton.TabStop = true;
             this.upJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -765,10 +718,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // buildCronLabel
             // 
             this.buildCronLabel.AutoSize = true;
-            this.buildCronLabel.Location = new System.Drawing.Point(9, 412);
-            this.buildCronLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.buildCronLabel.Location = new System.Drawing.Point(6, 297);
             this.buildCronLabel.Name = "buildCronLabel";
-            this.buildCronLabel.Size = new System.Drawing.Size(177, 20);
+            this.buildCronLabel.Size = new System.Drawing.Size(119, 13);
             this.buildCronLabel.TabIndex = 26;
             this.buildCronLabel.Text = "Build cron expression at";
             // 
@@ -776,11 +728,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.cronTriggerInfoTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.cronTriggerInfoTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(14, 182);
-            this.cronTriggerInfoTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.cronTriggerInfoTextBox.Location = new System.Drawing.Point(9, 147);
             this.cronTriggerInfoTextBox.Multiline = true;
             this.cronTriggerInfoTextBox.Name = "cronTriggerInfoTextBox";
-            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(322, 226);
+            this.cronTriggerInfoTextBox.Size = new System.Drawing.Size(215, 147);
             this.cronTriggerInfoTextBox.TabIndex = 25;
             this.cronTriggerInfoTextBox.TabStop = false;
             this.cronTriggerInfoTextBox.Text = resources.GetString("cronTriggerInfoTextBox.Text");
@@ -788,10 +739,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // cronmakerLinkLabel
             // 
             this.cronmakerLinkLabel.AutoSize = true;
-            this.cronmakerLinkLabel.Location = new System.Drawing.Point(189, 412);
-            this.cronmakerLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cronmakerLinkLabel.Location = new System.Drawing.Point(126, 297);
             this.cronmakerLinkLabel.Name = "cronmakerLinkLabel";
-            this.cronmakerLinkLabel.Size = new System.Drawing.Size(118, 20);
+            this.cronmakerLinkLabel.Size = new System.Drawing.Size(80, 13);
             this.cronmakerLinkLabel.TabIndex = 24;
             this.cronmakerLinkLabel.TabStop = true;
             this.cronmakerLinkLabel.Text = "cronmaker.com";
@@ -800,30 +750,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobCronExpressionLabel
             // 
             this.upJobCronExpressionLabel.AutoSize = true;
-            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(9, 117);
-            this.upJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.upJobCronExpressionLabel.Location = new System.Drawing.Point(6, 105);
             this.upJobCronExpressionLabel.Name = "upJobCronExpressionLabel";
-            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
+            this.upJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
             this.upJobCronExpressionLabel.TabIndex = 23;
             this.upJobCronExpressionLabel.Text = "Cron expression";
             // 
             // upJobCronExpressionTextBox
             // 
             this.upJobCronExpressionTextBox.Enabled = false;
-            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 142);
-            this.upJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 121);
             this.upJobCronExpressionTextBox.Name = "upJobCronExpressionTextBox";
-            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
+            this.upJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
             this.upJobCronExpressionTextBox.TabIndex = 17;
             this.upJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // upJobMinutesLabel
             // 
             this.upJobMinutesLabel.AutoSize = true;
-            this.upJobMinutesLabel.Location = new System.Drawing.Point(96, 34);
+            this.upJobMinutesLabel.Location = new System.Drawing.Point(64, 51);
             this.upJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobMinutesLabel.Name = "upJobMinutesLabel";
-            this.upJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
+            this.upJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
             this.upJobMinutesLabel.TabIndex = 5;
             this.upJobMinutesLabel.Text = "M:";
             this.upJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -831,10 +779,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobHoursLabel
             // 
             this.upJobHoursLabel.AutoSize = true;
-            this.upJobHoursLabel.Location = new System.Drawing.Point(9, 34);
+            this.upJobHoursLabel.Location = new System.Drawing.Point(6, 51);
             this.upJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.upJobHoursLabel.Name = "upJobHoursLabel";
-            this.upJobHoursLabel.Size = new System.Drawing.Size(25, 20);
+            this.upJobHoursLabel.Size = new System.Drawing.Size(18, 13);
             this.upJobHoursLabel.TabIndex = 4;
             this.upJobHoursLabel.Text = "H:";
             this.upJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -842,10 +790,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // upJobStartAtLabel
             // 
             this.upJobStartAtLabel.AutoSize = true;
-            this.upJobStartAtLabel.Location = new System.Drawing.Point(189, 34);
-            this.upJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.upJobStartAtLabel.Location = new System.Drawing.Point(126, 51);
             this.upJobStartAtLabel.Name = "upJobStartAtLabel";
-            this.upJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
+            this.upJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
             this.upJobStartAtLabel.TabIndex = 3;
             this.upJobStartAtLabel.Text = "start at";
             this.upJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -854,11 +801,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.upJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 29);
-            this.upJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 48);
             this.upJobStartAtDateTimePicker.Name = "upJobStartAtDateTimePicker";
             this.upJobStartAtDateTimePicker.ShowUpDown = true;
-            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
+            this.upJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
             this.upJobStartAtDateTimePicker.TabIndex = 14;
             this.upJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -866,11 +812,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobMinutesDateTimePicker.CustomFormat = "mm";
             this.upJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 29);
-            this.upJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 48);
             this.upJobMinutesDateTimePicker.Name = "upJobMinutesDateTimePicker";
             this.upJobMinutesDateTimePicker.ShowUpDown = true;
-            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.upJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.upJobMinutesDateTimePicker.TabIndex = 13;
             this.upJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 1, 0, 0);
             // 
@@ -878,11 +823,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.upJobHoursDateTimePicker.CustomFormat = "HH";
             this.upJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 29);
-            this.upJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.upJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 48);
             this.upJobHoursDateTimePicker.Name = "upJobHoursDateTimePicker";
             this.upJobHoursDateTimePicker.ShowUpDown = true;
-            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.upJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.upJobHoursDateTimePicker.TabIndex = 12;
             this.upJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -893,10 +837,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.bottomToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.cancelButton,
             this.addJobButton});
-            this.bottomToolStrip.Location = new System.Drawing.Point(0, 782);
+            this.bottomToolStrip.Location = new System.Drawing.Point(0, 515);
             this.bottomToolStrip.Name = "bottomToolStrip";
-            this.bottomToolStrip.Padding = new System.Windows.Forms.Padding(0, 0, 2, 0);
-            this.bottomToolStrip.Size = new System.Drawing.Size(1078, 32);
+            this.bottomToolStrip.Size = new System.Drawing.Size(723, 25);
             this.bottomToolStrip.TabIndex = 3;
             this.bottomToolStrip.Text = "toolStrip1";
             // 
@@ -906,7 +849,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.cancelButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.cancelButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(67, 29);
+            this.cancelButton.Size = new System.Drawing.Size(47, 22);
             this.cancelButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cancel;
             this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
             // 
@@ -916,7 +859,7 @@ namespace RecurringIntegrationsScheduler.Forms
             this.addJobButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.addJobButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.addJobButton.Name = "addJobButton";
-            this.addJobButton.Size = new System.Drawing.Size(146, 29);
+            this.addJobButton.Size = new System.Drawing.Size(97, 22);
             this.addJobButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_to_schedule;
             this.addJobButton.Click += new System.EventHandler(this.AddJobButton_Click);
             // 
@@ -941,11 +884,9 @@ namespace RecurringIntegrationsScheduler.Forms
             this.processingJobGroupBox.Controls.Add(this.procJobMinutesDateTimePicker);
             this.processingJobGroupBox.Controls.Add(this.procJobHoursDateTimePicker);
             this.processingJobGroupBox.Enabled = false;
-            this.processingJobGroupBox.Location = new System.Drawing.Point(375, 466);
-            this.processingJobGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.processingJobGroupBox.Location = new System.Drawing.Point(250, 303);
             this.processingJobGroupBox.Name = "processingJobGroupBox";
-            this.processingJobGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.processingJobGroupBox.Size = new System.Drawing.Size(345, 194);
+            this.processingJobGroupBox.Size = new System.Drawing.Size(230, 126);
             this.processingJobGroupBox.TabIndex = 4;
             this.processingJobGroupBox.TabStop = false;
             this.processingJobGroupBox.Text = "Processing monitor job";
@@ -954,19 +895,17 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobTriggerTypePanel.Controls.Add(this.procJobCronTriggerRadioButton);
             this.procJobTriggerTypePanel.Controls.Add(this.procJobSimpleTriggerRadioButton);
-            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(14, 74);
-            this.procJobTriggerTypePanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobTriggerTypePanel.Location = new System.Drawing.Point(9, 48);
             this.procJobTriggerTypePanel.Name = "procJobTriggerTypePanel";
-            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(312, 38);
+            this.procJobTriggerTypePanel.Size = new System.Drawing.Size(208, 25);
             this.procJobTriggerTypePanel.TabIndex = 38;
             // 
             // procJobCronTriggerRadioButton
             // 
             this.procJobCronTriggerRadioButton.AutoSize = true;
-            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(177, 3);
-            this.procJobCronTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobCronTriggerRadioButton.Location = new System.Drawing.Point(118, 2);
             this.procJobCronTriggerRadioButton.Name = "procJobCronTriggerRadioButton";
-            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(117, 24);
+            this.procJobCronTriggerRadioButton.Size = new System.Drawing.Size(79, 17);
             this.procJobCronTriggerRadioButton.TabIndex = 16;
             this.procJobCronTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Cron_trigger;
             this.procJobCronTriggerRadioButton.UseVisualStyleBackColor = true;
@@ -976,10 +915,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobSimpleTriggerRadioButton.AutoSize = true;
             this.procJobSimpleTriggerRadioButton.Checked = true;
-            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(4, 5);
-            this.procJobSimpleTriggerRadioButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobSimpleTriggerRadioButton.Location = new System.Drawing.Point(3, 3);
             this.procJobSimpleTriggerRadioButton.Name = "procJobSimpleTriggerRadioButton";
-            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(131, 24);
+            this.procJobSimpleTriggerRadioButton.Size = new System.Drawing.Size(88, 17);
             this.procJobSimpleTriggerRadioButton.TabIndex = 15;
             this.procJobSimpleTriggerRadioButton.TabStop = true;
             this.procJobSimpleTriggerRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Simple_trigger;
@@ -988,30 +926,28 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobCronExpressionLabel
             // 
             this.procJobCronExpressionLabel.AutoSize = true;
-            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(9, 122);
-            this.procJobCronExpressionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.procJobCronExpressionLabel.Location = new System.Drawing.Point(6, 79);
             this.procJobCronExpressionLabel.Name = "procJobCronExpressionLabel";
-            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(123, 20);
+            this.procJobCronExpressionLabel.Size = new System.Drawing.Size(82, 13);
             this.procJobCronExpressionLabel.TabIndex = 37;
             this.procJobCronExpressionLabel.Text = "Cron expression";
             // 
             // procJobCronExpressionTextBox
             // 
             this.procJobCronExpressionTextBox.Enabled = false;
-            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(14, 146);
-            this.procJobCronExpressionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobCronExpressionTextBox.Location = new System.Drawing.Point(9, 95);
             this.procJobCronExpressionTextBox.Name = "procJobCronExpressionTextBox";
-            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(320, 26);
+            this.procJobCronExpressionTextBox.Size = new System.Drawing.Size(215, 20);
             this.procJobCronExpressionTextBox.TabIndex = 36;
             this.procJobCronExpressionTextBox.Text = "0 0/15 8-18 ? * MON-FRI *";
             // 
             // procJobMinutesLabel
             // 
             this.procJobMinutesLabel.AutoSize = true;
-            this.procJobMinutesLabel.Location = new System.Drawing.Point(96, 38);
+            this.procJobMinutesLabel.Location = new System.Drawing.Point(64, 25);
             this.procJobMinutesLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobMinutesLabel.Name = "procJobMinutesLabel";
-            this.procJobMinutesLabel.Size = new System.Drawing.Size(26, 20);
+            this.procJobMinutesLabel.Size = new System.Drawing.Size(19, 13);
             this.procJobMinutesLabel.TabIndex = 32;
             this.procJobMinutesLabel.Text = "M:";
             this.procJobMinutesLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1019,10 +955,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobHoursLabel
             // 
             this.procJobHoursLabel.AutoSize = true;
-            this.procJobHoursLabel.Location = new System.Drawing.Point(9, 38);
+            this.procJobHoursLabel.Location = new System.Drawing.Point(6, 25);
             this.procJobHoursLabel.Margin = new System.Windows.Forms.Padding(0);
             this.procJobHoursLabel.Name = "procJobHoursLabel";
-            this.procJobHoursLabel.Size = new System.Drawing.Size(25, 20);
+            this.procJobHoursLabel.Size = new System.Drawing.Size(18, 13);
             this.procJobHoursLabel.TabIndex = 31;
             this.procJobHoursLabel.Text = "H:";
             this.procJobHoursLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1030,10 +966,9 @@ namespace RecurringIntegrationsScheduler.Forms
             // procJobStartAtLabel
             // 
             this.procJobStartAtLabel.AutoSize = true;
-            this.procJobStartAtLabel.Location = new System.Drawing.Point(189, 38);
-            this.procJobStartAtLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.procJobStartAtLabel.Location = new System.Drawing.Point(126, 25);
             this.procJobStartAtLabel.Name = "procJobStartAtLabel";
-            this.procJobStartAtLabel.Size = new System.Drawing.Size(59, 20);
+            this.procJobStartAtLabel.Size = new System.Drawing.Size(39, 13);
             this.procJobStartAtLabel.TabIndex = 30;
             this.procJobStartAtLabel.Text = "start at";
             this.procJobStartAtLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1042,11 +977,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobStartAtDateTimePicker.CustomFormat = "HH:mm";
             this.procJobStartAtDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(248, 34);
-            this.procJobStartAtDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobStartAtDateTimePicker.Location = new System.Drawing.Point(165, 22);
             this.procJobStartAtDateTimePicker.Name = "procJobStartAtDateTimePicker";
             this.procJobStartAtDateTimePicker.ShowUpDown = true;
-            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(76, 26);
+            this.procJobStartAtDateTimePicker.Size = new System.Drawing.Size(52, 20);
             this.procJobStartAtDateTimePicker.TabIndex = 35;
             this.procJobStartAtDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
@@ -1054,11 +988,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobMinutesDateTimePicker.CustomFormat = "mm";
             this.procJobMinutesDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(124, 34);
-            this.procJobMinutesDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobMinutesDateTimePicker.Location = new System.Drawing.Point(83, 22);
             this.procJobMinutesDateTimePicker.Name = "procJobMinutesDateTimePicker";
             this.procJobMinutesDateTimePicker.ShowUpDown = true;
-            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.procJobMinutesDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.procJobMinutesDateTimePicker.TabIndex = 34;
             this.procJobMinutesDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 30, 0, 0);
             // 
@@ -1066,21 +999,19 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.procJobHoursDateTimePicker.CustomFormat = "HH";
             this.procJobHoursDateTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(36, 34);
-            this.procJobHoursDateTimePicker.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.procJobHoursDateTimePicker.Location = new System.Drawing.Point(24, 22);
             this.procJobHoursDateTimePicker.Name = "procJobHoursDateTimePicker";
             this.procJobHoursDateTimePicker.ShowUpDown = true;
-            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(50, 26);
+            this.procJobHoursDateTimePicker.Size = new System.Drawing.Size(35, 20);
             this.procJobHoursDateTimePicker.TabIndex = 33;
             this.procJobHoursDateTimePicker.Value = new System.DateTime(2016, 6, 26, 0, 0, 0, 0);
             // 
             // useMonitoringJobCheckBox
             // 
             this.useMonitoringJobCheckBox.AutoSize = true;
-            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(374, 437);
-            this.useMonitoringJobCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.useMonitoringJobCheckBox.Location = new System.Drawing.Point(249, 284);
             this.useMonitoringJobCheckBox.Name = "useMonitoringJobCheckBox";
-            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(167, 24);
+            this.useMonitoringJobCheckBox.Size = new System.Drawing.Size(113, 17);
             this.useMonitoringJobCheckBox.TabIndex = 0;
             this.useMonitoringJobCheckBox.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Add_monitoring_job;
             this.useMonitoringJobCheckBox.UseVisualStyleBackColor = true;
@@ -1094,9 +1025,11 @@ namespace RecurringIntegrationsScheduler.Forms
             this.fileSelectionGroupBox.Controls.Add(this.orderLabel);
             this.fileSelectionGroupBox.Controls.Add(this.orderByLabel);
             this.fileSelectionGroupBox.Controls.Add(this.searchPatternLabel);
-            this.fileSelectionGroupBox.Location = new System.Drawing.Point(375, 20);
+            this.fileSelectionGroupBox.Location = new System.Drawing.Point(250, 13);
+            this.fileSelectionGroupBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.fileSelectionGroupBox.Name = "fileSelectionGroupBox";
-            this.fileSelectionGroupBox.Size = new System.Drawing.Size(345, 149);
+            this.fileSelectionGroupBox.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.fileSelectionGroupBox.Size = new System.Drawing.Size(230, 97);
             this.fileSelectionGroupBox.TabIndex = 5;
             this.fileSelectionGroupBox.TabStop = false;
             this.fileSelectionGroupBox.Text = "Files filter and order";
@@ -1105,28 +1038,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderByComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.orderByComboBox.FormattingEnabled = true;
-            this.orderByComboBox.Location = new System.Drawing.Point(87, 63);
+            this.orderByComboBox.Location = new System.Drawing.Point(58, 41);
+            this.orderByComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.orderByComboBox.Name = "orderByComboBox";
-            this.orderByComboBox.Size = new System.Drawing.Size(250, 28);
+            this.orderByComboBox.Size = new System.Drawing.Size(168, 21);
             this.orderByComboBox.TabIndex = 5;
             // 
             // panel1
             // 
             this.panel1.Controls.Add(this.orderDescendingRadioButton);
             this.panel1.Controls.Add(this.orderAscendingRadioButton);
-            this.panel1.Location = new System.Drawing.Point(66, 103);
+            this.panel1.Location = new System.Drawing.Point(44, 67);
             this.panel1.Margin = new System.Windows.Forms.Padding(0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(273, 37);
+            this.panel1.Size = new System.Drawing.Size(182, 24);
             this.panel1.TabIndex = 4;
             // 
             // orderDescendingRadioButton
             // 
             this.orderDescendingRadioButton.AutoSize = true;
-            this.orderDescendingRadioButton.Location = new System.Drawing.Point(150, 3);
+            this.orderDescendingRadioButton.Location = new System.Drawing.Point(100, 2);
             this.orderDescendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderDescendingRadioButton.Name = "orderDescendingRadioButton";
-            this.orderDescendingRadioButton.Size = new System.Drawing.Size(119, 24);
+            this.orderDescendingRadioButton.Size = new System.Drawing.Size(82, 17);
             this.orderDescendingRadioButton.TabIndex = 1;
             this.orderDescendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Descending;
             this.orderDescendingRadioButton.UseVisualStyleBackColor = true;
@@ -1135,10 +1069,10 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             this.orderAscendingRadioButton.AutoSize = true;
             this.orderAscendingRadioButton.Checked = true;
-            this.orderAscendingRadioButton.Location = new System.Drawing.Point(6, 3);
+            this.orderAscendingRadioButton.Location = new System.Drawing.Point(4, 2);
             this.orderAscendingRadioButton.Margin = new System.Windows.Forms.Padding(0);
             this.orderAscendingRadioButton.Name = "orderAscendingRadioButton";
-            this.orderAscendingRadioButton.Size = new System.Drawing.Size(109, 24);
+            this.orderAscendingRadioButton.Size = new System.Drawing.Size(75, 17);
             this.orderAscendingRadioButton.TabIndex = 0;
             this.orderAscendingRadioButton.TabStop = true;
             this.orderAscendingRadioButton.Text = global::RecurringIntegrationsScheduler.Properties.Resources.Ascending;
@@ -1146,36 +1080,40 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // searchPatternTextBox
             // 
-            this.searchPatternTextBox.Location = new System.Drawing.Point(129, 28);
+            this.searchPatternTextBox.Location = new System.Drawing.Point(86, 18);
+            this.searchPatternTextBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.searchPatternTextBox.Name = "searchPatternTextBox";
-            this.searchPatternTextBox.Size = new System.Drawing.Size(208, 26);
+            this.searchPatternTextBox.Size = new System.Drawing.Size(140, 20);
             this.searchPatternTextBox.TabIndex = 3;
             this.searchPatternTextBox.Text = "*.*";
             // 
             // orderLabel
             // 
             this.orderLabel.AutoSize = true;
-            this.orderLabel.Location = new System.Drawing.Point(6, 103);
+            this.orderLabel.Location = new System.Drawing.Point(4, 67);
+            this.orderLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.orderLabel.Name = "orderLabel";
-            this.orderLabel.Size = new System.Drawing.Size(49, 20);
+            this.orderLabel.Size = new System.Drawing.Size(33, 13);
             this.orderLabel.TabIndex = 2;
             this.orderLabel.Text = "Order";
             // 
             // orderByLabel
             // 
             this.orderByLabel.AutoSize = true;
-            this.orderByLabel.Location = new System.Drawing.Point(6, 66);
+            this.orderByLabel.Location = new System.Drawing.Point(4, 43);
+            this.orderByLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.orderByLabel.Name = "orderByLabel";
-            this.orderByLabel.Size = new System.Drawing.Size(69, 20);
+            this.orderByLabel.Size = new System.Drawing.Size(47, 13);
             this.orderByLabel.TabIndex = 1;
             this.orderByLabel.Text = "Order by";
             // 
             // searchPatternLabel
             // 
             this.searchPatternLabel.AutoSize = true;
-            this.searchPatternLabel.Location = new System.Drawing.Point(6, 31);
+            this.searchPatternLabel.Location = new System.Drawing.Point(4, 20);
+            this.searchPatternLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.searchPatternLabel.Name = "searchPatternLabel";
-            this.searchPatternLabel.Size = new System.Drawing.Size(115, 20);
+            this.searchPatternLabel.Size = new System.Drawing.Size(77, 13);
             this.searchPatternLabel.TabIndex = 0;
             this.searchPatternLabel.Text = "Search pattern";
             // 
@@ -1185,26 +1123,23 @@ namespace RecurringIntegrationsScheduler.Forms
             this.retryPolicyGroupBox.Controls.Add(this.retriesCountUpDown);
             this.retryPolicyGroupBox.Controls.Add(this.label2);
             this.retryPolicyGroupBox.Controls.Add(this.label1);
-            this.retryPolicyGroupBox.Location = new System.Drawing.Point(374, 671);
-            this.retryPolicyGroupBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retryPolicyGroupBox.Location = new System.Drawing.Point(249, 436);
             this.retryPolicyGroupBox.Name = "retryPolicyGroupBox";
-            this.retryPolicyGroupBox.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.retryPolicyGroupBox.Size = new System.Drawing.Size(346, 143);
+            this.retryPolicyGroupBox.Size = new System.Drawing.Size(231, 93);
             this.retryPolicyGroupBox.TabIndex = 6;
             this.retryPolicyGroupBox.TabStop = false;
             this.retryPolicyGroupBox.Text = "Retry policy";
             // 
             // retriesDelayUpDown
             // 
-            this.retriesDelayUpDown.Location = new System.Drawing.Point(150, 65);
-            this.retriesDelayUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesDelayUpDown.Location = new System.Drawing.Point(100, 42);
             this.retriesDelayUpDown.Maximum = new decimal(new int[] {
             86400,
             0,
             0,
             0});
             this.retriesDelayUpDown.Name = "retriesDelayUpDown";
-            this.retriesDelayUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesDelayUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesDelayUpDown.TabIndex = 5;
             this.retriesDelayUpDown.Value = new decimal(new int[] {
             60,
@@ -1214,15 +1149,14 @@ namespace RecurringIntegrationsScheduler.Forms
             // 
             // retriesCountUpDown
             // 
-            this.retriesCountUpDown.Location = new System.Drawing.Point(150, 28);
-            this.retriesCountUpDown.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.retriesCountUpDown.Location = new System.Drawing.Point(100, 18);
             this.retriesCountUpDown.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.retriesCountUpDown.Name = "retriesCountUpDown";
-            this.retriesCountUpDown.Size = new System.Drawing.Size(99, 26);
+            this.retriesCountUpDown.Size = new System.Drawing.Size(66, 20);
             this.retriesCountUpDown.TabIndex = 4;
             this.retriesCountUpDown.Value = new decimal(new int[] {
             1,
@@ -1233,29 +1167,29 @@ namespace RecurringIntegrationsScheduler.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 68);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(7, 44);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(123, 20);
+            this.label2.Size = new System.Drawing.Size(83, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Delay (seconds)";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(10, 31);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(7, 20);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(131, 20);
+            this.label1.Size = new System.Drawing.Size(87, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Number of retries";
             // 
             // groupBoxExceptions
             // 
             this.groupBoxExceptions.Controls.Add(this.pauseOnExceptionsCheckBox);
-            this.groupBoxExceptions.Location = new System.Drawing.Point(729, 666);
+            this.groupBoxExceptions.Location = new System.Drawing.Point(486, 475);
+            this.groupBoxExceptions.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.groupBoxExceptions.Name = "groupBoxExceptions";
-            this.groupBoxExceptions.Size = new System.Drawing.Size(345, 59);
+            this.groupBoxExceptions.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBoxExceptions.Size = new System.Drawing.Size(230, 38);
             this.groupBoxExceptions.TabIndex = 10;
             this.groupBoxExceptions.TabStop = false;
             this.groupBoxExceptions.Text = "Exceptions";
@@ -1265,19 +1199,31 @@ namespace RecurringIntegrationsScheduler.Forms
             this.pauseOnExceptionsCheckBox.AutoSize = true;
             this.pauseOnExceptionsCheckBox.Checked = true;
             this.pauseOnExceptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(13, 26);
+            this.pauseOnExceptionsCheckBox.Location = new System.Drawing.Point(9, 17);
+            this.pauseOnExceptionsCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.pauseOnExceptionsCheckBox.Name = "pauseOnExceptionsCheckBox";
-            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(270, 24);
+            this.pauseOnExceptionsCheckBox.Size = new System.Drawing.Size(186, 17);
             this.pauseOnExceptionsCheckBox.TabIndex = 0;
             this.pauseOnExceptionsCheckBox.Text = "Pause job when exception occurs";
             this.pauseOnExceptionsCheckBox.UseVisualStyleBackColor = true;
             // 
+            // pauseIndefinitelyCheckBox
+            // 
+            this.pauseIndefinitelyCheckBox.AutoSize = true;
+            this.pauseIndefinitelyCheckBox.Location = new System.Drawing.Point(9, 17);
+            this.pauseIndefinitelyCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.pauseIndefinitelyCheckBox.Name = "pauseIndefinitelyCheckBox";
+            this.pauseIndefinitelyCheckBox.Size = new System.Drawing.Size(125, 17);
+            this.pauseIndefinitelyCheckBox.TabIndex = 0;
+            this.pauseIndefinitelyCheckBox.Text = "Pause job indefinitely";
+            this.pauseIndefinitelyCheckBox.UseVisualStyleBackColor = true;
+            // 
             // UploadJob
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(1078, 814);
+            this.ClientSize = new System.Drawing.Size(723, 540);
             this.Controls.Add(this.bottomToolStrip);
             this.Controls.Add(this.groupBoxExceptions);
             this.Controls.Add(this.retryPolicyGroupBox);
@@ -1288,11 +1234,10 @@ namespace RecurringIntegrationsScheduler.Forms
             this.Controls.Add(this.jobDetailsGroupBox);
             this.Controls.Add(this.useMonitoringJobCheckBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(1100, 870);
+            this.MaximumSize = new System.Drawing.Size(739, 579);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(1100, 870);
+            this.MinimumSize = new System.Drawing.Size(739, 579);
             this.Name = "UploadJob";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -1429,5 +1374,6 @@ namespace RecurringIntegrationsScheduler.Forms
         private System.Windows.Forms.NumericUpDown retriesCountUpDown;
         private System.Windows.Forms.GroupBox groupBoxExceptions;
         private System.Windows.Forms.CheckBox pauseOnExceptionsCheckBox;
+        private System.Windows.Forms.CheckBox pauseIndefinitelyCheckBox;
     }
 }

--- a/Scheduler/Forms/UploadJob.cs
+++ b/Scheduler/Forms/UploadJob.cs
@@ -231,6 +231,10 @@ namespace RecurringIntegrationsScheduler.Forms
                                                          UploadJobDetail.JobDataMap[SettingsConstants.ReverseOrder]
                                                              .ToString());
 
+                pauseIndefinitelyCheckBox.Checked =
+                    (UploadJobDetail.JobDataMap[SettingsConstants.IndefinitePause] != null) &&
+                    Convert.ToBoolean(UploadJobDetail.JobDataMap[SettingsConstants.IndefinitePause].ToString());
+
                 if (UploadTrigger.GetType() == typeof(SimpleTriggerImpl))
                 {
                     var localTrigger = (SimpleTriggerImpl) UploadTrigger;
@@ -578,7 +582,8 @@ namespace RecurringIntegrationsScheduler.Forms
                 {SettingsConstants.ReverseOrder, orderDescendingRadioButton.Checked.ToString()},
                 {SettingsConstants.RetryCount, retriesCountUpDown.Value.ToString(CultureInfo.InvariantCulture)},
                 {SettingsConstants.RetryDelay, retriesDelayUpDown.Value.ToString(CultureInfo.InvariantCulture)},
-                {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()}
+                {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()},
+                {SettingsConstants.IndefinitePause, pauseIndefinitelyCheckBox.Checked.ToString()}
             };
             if (serviceAuthRadioButton.Checked)
             {
@@ -613,7 +618,8 @@ namespace RecurringIntegrationsScheduler.Forms
                 {SettingsConstants.UseServiceAuthentication, serviceAuthRadioButton.Checked.ToString()},
                 {SettingsConstants.RetryCount, retriesCountUpDown.Value.ToString(CultureInfo.InvariantCulture)},
                 {SettingsConstants.RetryDelay, retriesDelayUpDown.Value.ToString(CultureInfo.InvariantCulture)},
-                {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()}
+                {SettingsConstants.PauseJobOnException, pauseOnExceptionsCheckBox.Checked.ToString()},
+                {SettingsConstants.IndefinitePause, pauseIndefinitelyCheckBox.Checked.ToString()}
             };
             if (serviceAuthRadioButton.Checked)
             {

--- a/Scheduler/Forms/UploadJob.resx
+++ b/Scheduler/Forms/UploadJob.resx
@@ -125,7 +125,4 @@
 
 Default example above means: Each working day of the week (MON-FRI) run every 15 minutes (0/15) between 8:00 and 18:45 (8-18 - last run will be at 18:45)</value>
   </data>
-  <metadata name="bottomToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>245, 17</value>
-  </metadata>
 </root>

--- a/Scheduler/packages.config
+++ b/Scheduler/packages.config
@@ -4,5 +4,5 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="Polly" version="5.8.0" targetFramework="net461" />
   <package id="PortableSettingsProvider" version="0.1.0" targetFramework="net46" />
-  <package id="Quartz" version="3.0.6" targetFramework="net46" />
+  <package id="Quartz" version="3.0.6" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Issue #45 Requested the ability to keep the pause status of jobs even after the service is restarted. Since Quartz.NET doesn't allow saving the status in the XML file, I implemented this by adding a new checkbox to each job type above the trigger section to pause the job indefinitely. Once the box is checked and the job is saved, the very next time the job is run by the Quartz server, the first thing it will do is check that value (before trying to upload/download/import/export) and if it is true, it will pause the job. To un-pause the job, requires selecting the job and clicking edit job and unchecking the box and saving the job.